### PR TITLE
Fix grammar and update JAMstack Dallas URL

### DIFF
--- a/site/data/bestpractices.yaml
+++ b/site/data/bestpractices.yaml
@@ -7,7 +7,7 @@ bestpractices:
   - title: Modern Build Tools
     description: Take advantage of the world of modern build tools. It can be a jungle to get oriented in and it's a fast moving space, but you'll want to be able to use tomorrow's web standards today without waiting for tomorrow's browsers. And that currently means, Babel, PostCSS, Webpack, and friends.
   - title: Automated Builds
-    description: Because JAMstack markup pre-built, content changes won’t go live until you run another build. Automating this process will save you lots of headache. You can do this yourself with webhooks, or use a publishing platform that includes the service automatically.
+    description: Because JAMstack markup is prebuilt, content changes won’t go live until you run another build. Automating this process will save you lots of headache. You can do this yourself with webhooks, or use a publishing platform that includes the service automatically.
   - title: Atomic Deploys
     description: As JAMstack projects grow really large, new changes might require re-deployment of hundreds files. Uploading these one at a time can cause inconsistent state while the process completes. You can avoid this with a system that lets you do "atomic deploys," where no changes go live until all changed files have been uploaded.
   - title: Instant Cache Invalidation

--- a/site/data/community.yaml
+++ b/site/data/community.yaml
@@ -7,7 +7,7 @@ chapters:
   - name: JAMstack Dallas
     artpath: /img/chapters/dallas-art.svg
     btncopy: Join Now
-    link: https://www.meetup.com/JAMstack-Meetup/
+    link: https://www.meetup.com/jamstack-dallas/
   - name: JAMstack London
     artpath: /img/chapters/london-art.svg
     btncopy: Coming Soon

--- a/site/data/definitions.yaml
+++ b/site/data/definitions.yaml
@@ -4,7 +4,7 @@ explanation: When we talk about "The Stack," we no longer talk about operating s
 
 javascript: "Any dynamic programming during the request/response cycle is handled by JavaScript, running entirely on the client. This could be any frontend framework, library, or even vanilla JavaScript."
 apis: "All server-side processes or database actions are abstracted into reusable APIs, accessed over HTTP with JavaScript. These can be custom-built or leverage third-party services."
-markup: "Templated markup should be pre-built at deploy time, usually using a site generator for content sites, or a build tool for web apps.<br><br>[Want to see some examples?](/examples)"
+markup: "Templated markup should be prebuilt at deploy time, usually using a site generator for content sites, or a build tool for web apps.<br><br>[Want to see some examples?](/examples)"
 
 disqualifications:
   - disqualification: A site built with a server-side CMS like WordPress, Drupal, Joomla, or Squarespace.


### PR DESCRIPTION
> Because JAMstack markup pre-built

The statement above feels like it's missing a verb. 

I also changed "pre-built" to be consistent with how prebuilt appears on `index.html`