### PR TITLE
docs(examples): add alt text and title for thumbs

### DIFF
--- a/site/layouts/pages/examples.html
+++ b/site/layouts/pages/examples.html
@@ -15,7 +15,7 @@
           <div class="browser">
             <div class="controls">•••</div>
           </div>
-          <img src="{{ .thumbnailurl }}"/>
+          <img src="{{ .thumbnailurl }}" alt="{{ .title }} screenshot">
           <h1>{{ .title }}</h1>
           <ul class="tools">
             {{ range .tools }}


### PR DESCRIPTION
adds alt text to example thumbs for improved aural experience, uses example description to provide
thumbnail mouseover text and removes self-closing tag on void element