### PR TITLE
feat(resources/articles): add article descriptions

### DIFF
--- a/site/data/resources.yaml
+++ b/site/data/resources.yaml
@@ -1,14 +1,19 @@
 ---
 articles:
   - title: A JAMstack-ready CMS
+    description: Where does a CMS stand in the JAMstack architecture? And is it a good idea to follow the API-based content-as-a-service approach?
     link: https://www.contentful.com/r/knowledgebase/jamstack-cms/
   - title: Isomorphic Rendering on the JAMstack
+    description: A simplified yet powerful model for delivering ready-to-consume web pages which enhance to a dynamic client-side rendering approach.
     link: https://www.hawksworx.com/blog/isomorphic-rendering-on-the-jam-stack/
   - title: Dynamic product management in a static e-commerce workflow
+    description: This is a guest post by Yanick Ouellet, a full-stack developer at Snipcart, in which he shows how to combine the benefits of dynamic content management and a static e-commerce website using Snipcart, Contentful, and Middleman.
     link: https://www.contentful.com/blog/2016/02/10/snipcart-middleman-contentful
   - title: "JAMstack for Clients: On Benefits & Static Site CMS"
+    description: Learn more about the implications of the JAMstack (JavaScript, APIs & Markup) & static site CMS for non-technical clients & businesses.
     link: https://snipcart.com/blog/jamstack-clients-static-site-cms
   - title: "Go static: 5 reasons to try JAMstack on your next project"
+    description: Static site generators and ultra-fast CDN-based distribution are powering a new generation of websites. The time to embrace this is now.
     link: https://builtvisible.com/go-static-try-jamstack/
 
 videos:

--- a/site/layouts/pages/resources.html
+++ b/site/layouts/pages/resources.html
@@ -29,7 +29,7 @@
         <li>
           <a href="{{ .link }}">
             <h2>{{ .title }}</h2>
-            <small>{{ .description | truncate 160 }}</small>
+            <small>{{ .description }}</small>
             <span class="arrow">→</span>
           </a>
         </li>

--- a/site/layouts/pages/resources.html
+++ b/site/layouts/pages/resources.html
@@ -28,8 +28,9 @@
       {{ range .Site.Data.resources.articles }}
         <li>
           <a href="{{ .link }}">
-            <h3>{{ .title }}</h3>
-            <span>→</span>
+            <h2>{{ .title }}</h2>
+            <small>{{ .description | truncate 160 }}</small>
+            <span class="arrow">→</span>
           </a>
         </li>
       {{ end }}

--- a/src/css/imports/resources.css
+++ b/src/css/imports/resources.css
@@ -131,6 +131,7 @@
 
   .articles-list {
     display: block;
+    font-family: $roboto;
     list-style-type: none;
     margin: 32px auto 0 auto;
     text-align: left;
@@ -163,7 +164,12 @@
           color: white;
         }
 
+        small {
+          color: white;
+        }
+
         span {
+          visibility: visible;
           transform: translateX($small);
         }
       }
@@ -181,7 +187,6 @@
 
       h2, a {
         color: $grey;
-        display: inline-block;
         flex: 1;
         vertical-align: bottom;
 
@@ -199,19 +204,26 @@
         }
       }
 
-      h3 {
-        display: inline-block;
+      h2 {
+        font-size: $tiny;
       }
 
       a {
         cursor: pointer;
-        padding: $tiny $medium $tiny 0;
+        padding: $tiny $small $tiny 0;
         position: relative;
+
+        @media screen and (min-width: $tablet) {
+          padding-right: $xxl;
+        }
       }
 
-      span {
-        color: white;
-        font-family: $roboto;
+      small {
+        color: $green;
+      }
+
+      .arrow {
+        visibility: hidden;
         font-size: 14px;
         float: right;
         text-align: right;


### PR DESCRIPTION
adds article descriptions using description meta, <del>truncated at 160 characters,</del> and improves the
treatment of article ux, helping them stand out more

![articles-update](https://cloud.githubusercontent.com/assets/440298/24576133/aefe6776-16e8-11e7-9780-def8f33556b5.png)

