### PR TITLE
Remove Active Ingredients

### DIFF
--- a/site/layouts/pages/community.html
+++ b/site/layouts/pages/community.html
@@ -20,7 +20,7 @@
     </div>
   </div>
 
-  <section class="upcoming-event grid contained">
+  <!--<section class="upcoming-event grid contained">
     <div class="hook">
       <h1>Upcoming Events</h1>
       <p>
@@ -36,7 +36,7 @@
         <strong>When? </strong>{{ .Site.Data.community.upcomingevent.date }}
       </p>
     </a>
-  </section>
+  </section>-->
 
   <div class="bottom-cta">
     <div class="contained">


### PR DESCRIPTION
Active Ingredients is over. Need to add a layout for a list of multiple events, then update the data to match. For a quick fix in the meantime, I'm commenting out the events section in the layout.