### PR TITLE
WIP: First try at multilingual support

### DIFF
--- a/config_en.toml
+++ b/config_en.toml
@@ -1,0 +1,5 @@
+title = "JAMstack.org"
+
+[params]
+    locale = "en-us"
+

--- a/config_uk.toml
+++ b/config_uk.toml
@@ -1,0 +1,4 @@
+title = "JAMstack.uk"
+
+[params]
+    locale = "en-uk"

--- a/site/data/bestpractices_uk.yaml
+++ b/site/data/bestpractices_uk.yaml
@@ -1,0 +1,15 @@
+---
+bestpractices:
+  - title: Entire Project on a CDN
+    description: Because JAMstack projects don’t rely on server-side code, they can be distributed instead of living on a single server. Serving directly from a CDN unlocks speeds and performance that can't be beat. The more of your app you can push to the edge, the better the user experience.
+  - title: Everything Lives in Git
+    description: With a JAMstack project, anyone should be able to do a `git clone` , install any needed dependencies with a standard procedure (like `npm install`), and be ready to run the full project locally. No databases to clone, no complex installs. This reduces contributor friction, and also simplifies staging and testing workflows.
+  - title: Modern Build Tools
+    description: Take advantage of the world of modern build tools. It can be a jungle to get oriented in and it's a fast moving space, but you'll want to be able to use tomorrow's web standards today without waiting for tomorrow's browsers. And that currently means, Babel, PostCSS, Webpack, and friends.
+  - title: Automated Builds
+    description: Because JAMstack markup is prebuilt, content changes won’t go live until you run another build. Automating this process will save you lots of headache. You can do this yourself with webhooks, or use a publishing platform that includes the service automatically.
+  - title: Atomic Deploys
+    description: As JAMstack projects grow really large, new changes might require re-deploying hundreds files. Uploading these one at a time can cause inconsistent state while the process completes. You can avoid this with a system that lets you do "atomic deploys", where no changes go live until all changed files have been uploaded.
+  - title: Instant Cache Invalidation
+    description: When the build-to-deploy cycle becomes a regular occurrence, you need to know that when a deploy goes live, it really goes live. Eliminate any doubt by making sure your CDN can handle instant cache purges.
+---

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -2,7 +2,9 @@
 
 <section class="hero">
   <div class="contained">
-    <h1>{{ .Site.Data.definitions.jamstack | markdownify }}</h1>
+    <h1>
+      {{ .Site.Data.definitions.jamstack | markdownify }}
+    </h1>
   </div>
 </section>
 

--- a/site/layouts/pages/best-practices.html
+++ b/site/layouts/pages/best-practices.html
@@ -5,11 +5,21 @@
     <h1 class="headline">Best Practices</h1>
     <p class ="cta">When building JAMstack projects, you can really get the most out of the stack if you stick to a few best practices.</p>
     <div class="grid">
-      {{ range .Site.Data.bestpractices.bestpractices }}
-        <div class="best-practice">
-          <h4><img src="/img/thumbs-up.svg" /> {{ .title }}</h4>
-          <p>{{ .description }}</p>
-        </div>
+      {{ if eq .Site.Params.locale "en-us" }}
+        {{ range .Site.Data.bestpractices.bestpractices }}
+          <div class="best-practice">
+            <h4><img src="/img/thumbs-up.svg" /> {{ .title }}</h4>
+            <p>{{ .description }}</p>
+          </div>
+        {{ end }}
+      {{ end }}
+      {{ if eq .Site.Params.locale "en-uk" }}
+        {{ range .Site.Data.bestpractices_uk.bestpractices }}
+          <div class="best-practice">
+            <h4><img src="/img/thumbs-up.svg" /> {{ .title }}</h4>
+            <p>{{ .description }}</p>
+          </div>
+        {{ end }}
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
# What is this?

per #52 and the comments on #40, I wanted to test out getting multilingual on JAMstack.org, but having initials issues. I am following the [Hugo guides on the subject](https://gohugo.io/tutorials/create-a-multilingual-site/) as a source of truth, though I think I am missing something. 

I made a small change in the bestpractices_uk.yaml to render the after the "atomic deploys" when the language is UK

This is a quick and dirty attempt, however, it renders no content when I change the language. I don't think I am testing this correctly. 

![screenshot 2017-05-01 17 48 13](https://cloud.githubusercontent.com/assets/5713670/25600106/8fd834ba-2e96-11e7-8e06-2d8bf17dc967.png)

I created this PR to trigger a deploy preview that I can test from. 

# Help
Looking for initial feedback on the direction of this and if there are any experts on the subject in getting this to work with Hugo.