### PR TITLE
Redirect staticwebtech.com to jamstack.org

### DIFF
--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -12,3 +12,8 @@ https://jam-stack.org/* https://jamstack.org/:splat 301!
 https://www.jam-stack.org/* https://jamstack.org/:splat 301!
 http://jam-stack.org/* https://jamstack.org/:splat 301!
 http://www.jam-stack.org/* https://jamstack.org/:splat 301!
+
+https://staticwebtech.com/* https://jamstack.org 301!
+https://www.staticwebtech.com/* https://jamstack.org 301!
+http://staticwebtech.com/* https://jamstack.org 301!
+http://www.staticwebtech.com/* https://jamstack.org 301!


### PR DESCRIPTION
Because SWT links don't really map to jamstack.org links, I'm keeping this simple and redirecting to the homepage in all cases, leaving out the `:splat`.