### PR TITLE
Hugo site restructure for jamstack.org to be more hugo-centric

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,6 +17,7 @@ import webpackConfig from "./webpack.conf";
 const browserSync = BrowserSync.create();
 const hugoBin = "hugo";
 const defaultArgs = ["-d", "../dist", "-s", "site", "-v"];
+const DEST = "./dist/";
 
 gulp.task("hugo", (cb) => buildSite(cb));
 gulp.task("hugo-preview", (cb) => buildSite(cb, ["--buildDrafts", "--buildFuture"]));
@@ -34,7 +35,7 @@ gulp.task("css", () => (
       hdBackgrounds(),
       cssextend(),
       cssvars({variables: styleVariables})]))
-    .pipe(gulp.dest("./dist/css"))
+    .pipe(gulp.dest(DEST+"css"))
     .pipe(browserSync.stream())
 ));
 
@@ -54,13 +55,13 @@ gulp.task("js", (cb) => {
 
 gulp.task("fonts", () => (
   gulp.src("./src/fonts/**/*")
-    .pipe(gulp.dest("./dist/fonts"))
+    .pipe(gulp.dest(DEST+"fonts"))
     .pipe(browserSync.stream())
 ));
 
 gulp.task("images", () => (
   gulp.src("./src/img/**/*")
-    .pipe(gulp.dest("./dist/img"))
+    .pipe(gulp.dest(DEST+"img"))
     .pipe(browserSync.stream())
 ));
 

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -1,5 +1,7 @@
 baseurl: DEPLOY_PRIME_URL
 languageCode: "en-us"
 title: "JAMstack | JavaScript, APIs, and Markup"
-disable404: true
+disableKinds: ["404"]
 metaDataFormat: "yaml"
+
+publishDir: "dist"

--- a/site/content/best-practices.md
+++ b/site/content/best-practices.md
@@ -1,5 +1,6 @@
 ---
+type: page
 title: Best Practices
-url: '/best-practices/'
+url: "/best-practices/"
 layout: best-practices
 ---

--- a/site/content/community.md
+++ b/site/content/community.md
@@ -1,0 +1,6 @@
+---
+type: page
+title: Community
+url: "/community/"
+layout: "community"
+---

--- a/site/content/examples.md
+++ b/site/content/examples.md
@@ -1,0 +1,6 @@
+---
+type: page
+title: Examples
+url: "/examples/"
+layout: "examples"
+---

--- a/site/content/pages/community.html
+++ b/site/content/pages/community.html
@@ -1,5 +1,0 @@
----
-title: Community
-url: '/community/'
-layout: community
----

--- a/site/content/pages/examples.html
+++ b/site/content/pages/examples.html
@@ -1,5 +1,0 @@
----
-title: Examples
-url: '/examples/'
-layout: examples
----

--- a/site/content/pages/resources.html
+++ b/site/content/pages/resources.html
@@ -1,5 +1,0 @@
----
-title: Resources
-url: '/resources/'
-layout: resources
----

--- a/site/content/resources.md
+++ b/site/content/resources.md
@@ -1,0 +1,6 @@
+---
+type: page
+title: Resources
+url: "/resources/"
+layout: "resources"
+---

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  {{ partial "html-head" . }}
+  <body>
+    {{ partial "header" . }}
+    {{ block "main" . }}{{ end }}
+    {{ partial "footer" . }}
+    {{ partial "scripts" . }}
+    {{ block "page-scripts" . }}{{ end }}
+  </body>
+</html>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,71 +1,69 @@
-{{ partial "header" . }}
-
+{{ define "main" }}
 <section class="hero">
-  <div class="contained">
-    <h1>{{ .Site.Data.definitions.jamstack | markdownify }}</h1>
-  </div>
-</section>
-
-<section class="intro">
-  <div class="contained grid">
-    <div>{{ .Site.Data.definitions.explanation | markdownify }}</div>
-    <div>
-      <h1>FAQ</h1>
-      <a class="text-link scrolling-link" href="#what"><h4>What is the JAMstack?</h4></a>
-      <a class="text-link scrolling-link" href="#why"><h4>Why the JAMstack?</h4></a>
-      <a class="text-link scrolling-link" href="#how"><h4>How do I get started?</h4></a>
+    <div class="contained">
+      <h1>{{ .Site.Data.definitions.jamstack | markdownify }}</h1>
     </div>
-  </div>
-</section>
-
-<section id="what" class="jam-breakdown">
-  <div class="contained intro">
-    <h1>What is the JAMstack?</h1>
-    <p>Your project is built with the JAMstack if it meets three key criteria:</p>
-  </div>
-  <div class="letter-definition">
-    <img class="letter" src="/img/j.svg"/>
-    <h1>JavaScript</h1>
-    <p>{{ .Site.Data.definitions.javascript | markdownify }}</p>
-  </div>
-  <div class="letter-definition">
-    <img class="letter" src="/img/a.svg"/>
-    <h1>APIs</h1>
-    <p>{{ .Site.Data.definitions.apis | markdownify }}</p>
-  </div>
-  <div class="letter-definition">
-    <img class="letter" src="/img/m.svg"/>
-    <h1>Markup</h1>
-    <p>{{ .Site.Data.definitions.markup | markdownify }}</p>
-  </div>
-</section>
-
-<section class="jam-disqualifications contained">
-  <h1>When is your site <em>not</em> built with the JAMstack?</h1>
-  <p>Any project that relies on a tight coupling between client and server is not built with the JAMstack. This would include:</p>
-  <div class="disqualifications">
-    {{ range .Site.Data.definitions.disqualifications }}
-      <h4 class="disqualification">{{ .disqualification | markdownify }}</h4>
-    {{ end }}
-  </div>
-</section>
-
-<section id="why" class="advantages contained">
-  <h1>Why the JAMstack?</h1>
-  <div class="advantages-grid">
-    {{ range .Site.Data.definitions.advantages }}
-      <div class="advantage">
-        <h4>{{ .advantage | markdownify }}</h4>
-        <p>{{ .description | markdownify }}</p>
+  </section>
+  
+  <section class="intro">
+    <div class="contained grid">
+      <div>{{ .Site.Data.definitions.explanation | markdownify }}</div>
+      <div>
+        <h1>FAQ</h1>
+        <a class="text-link scrolling-link" href="#what"><h4>What is the JAMstack?</h4></a>
+        <a class="text-link scrolling-link" href="#why"><h4>Why the JAMstack?</h4></a>
+        <a class="text-link scrolling-link" href="#how"><h4>How do I get started?</h4></a>
       </div>
-    {{ end }}
-  </div>
-</section>
-
-<section id="how" class="bottom-cta contained">
-  <h1>How do I get started?</h1>
-  <a href="/best-practices"><h4>Learn About Best Practices →</h4></a>
-  <a href="/resources"><h4>View Resources →</h4></a>
-</section>
-
-{{ partial "footer" . }}
+    </div>
+  </section>
+  
+  <section id="what" class="jam-breakdown">
+    <div class="contained intro">
+      <h1>What is the JAMstack?</h1>
+      <p>Your project is built with the JAMstack if it meets three key criteria:</p>
+    </div>
+    <div class="letter-definition">
+      <img class="letter" src="/img/j.svg"/>
+      <h1>JavaScript</h1>
+      <p>{{ .Site.Data.definitions.javascript | markdownify }}</p>
+    </div>
+    <div class="letter-definition">
+      <img class="letter" src="/img/a.svg"/>
+      <h1>APIs</h1>
+      <p>{{ .Site.Data.definitions.apis | markdownify }}</p>
+    </div>
+    <div class="letter-definition">
+      <img class="letter" src="/img/m.svg"/>
+      <h1>Markup</h1>
+      <p>{{ .Site.Data.definitions.markup | markdownify }}</p>
+    </div>
+  </section>
+  
+  <section class="jam-disqualifications contained">
+    <h1>When is your site <em>not</em> built with the JAMstack?</h1>
+    <p>Any project that relies on a tight coupling between client and server is not built with the JAMstack. This would include:</p>
+    <div class="disqualifications">
+      {{ range .Site.Data.definitions.disqualifications }}
+        <h4 class="disqualification">{{ .disqualification | markdownify }}</h4>
+      {{ end }}
+    </div>
+  </section>
+  
+  <section id="why" class="advantages contained">
+    <h1>Why the JAMstack?</h1>
+    <div class="advantages-grid">
+      {{ range .Site.Data.definitions.advantages }}
+        <div class="advantage">
+          <h4>{{ .advantage | markdownify }}</h4>
+          <p>{{ .description | markdownify }}</p>
+        </div>
+      {{ end }}
+    </div>
+  </section>
+  
+  <section id="how" class="bottom-cta contained">
+    <h1>How do I get started?</h1>
+    <a href="/best-practices"><h4>Learn About Best Practices →</h4></a>
+    <a href="/resources"><h4>View Resources →</h4></a>
+  </section>
+{{ end }}

--- a/site/layouts/page/baseof.html
+++ b/site/layouts/page/baseof.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  {{ partial "html-head" . }}
+  <body>
+    {{ partial "header" . }}
+    {{ block "main" . }}{{ end }}
+    {{ partial "footer" . }}
+    {{ partial "scripts" . }}
+    {{ block "page-scripts" . }}{{ end }}
+  </body>
+</html>

--- a/site/layouts/page/best-practices.html
+++ b/site/layouts/page/best-practices.html
@@ -1,5 +1,4 @@
-{{ partial "header" . }}
-
+{{ define "main" }}
 <div class="best-practices">
   <div class="contained">
     <h1 class="headline">Best Practices</h1>
@@ -14,5 +13,4 @@
     </div>
   </div>
 </div>
-
-{{ partial "footer" . }}
+{{ end }}

--- a/site/layouts/page/community.html
+++ b/site/layouts/page/community.html
@@ -1,5 +1,4 @@
-{{ partial "header" . }}
-
+{{ define "main" }}
 <div class="community">
 
   <section class="hero">
@@ -124,5 +123,4 @@
     </div>
   </section>
 </div>
-
-{{ partial "footer" . }}
+{{ end }}

--- a/site/layouts/page/examples.html
+++ b/site/layouts/page/examples.html
@@ -1,5 +1,4 @@
-{{ partial "header" . }}
-
+{{ define "main" }}
 <div class="examples">
   <div class="contained">
     <div class="cta grid">
@@ -27,5 +26,4 @@
     </div>
   </div>
 </div>
-
-{{ partial "footer" . }}
+{{ end }}

--- a/site/layouts/page/resources.html
+++ b/site/layouts/page/resources.html
@@ -1,4 +1,4 @@
-{{ partial "header" . }}
+{{ define "main" }}
 
 <div class="resources">
   <h1 class="contained">Resources</h1>
@@ -8,51 +8,6 @@
   </p>
 
   <section class="videos contained">
-
-    <script>
-      function loadVids() {
-        $.get(
-          "https://www.googleapis.com/youtube/v3/channels",{
-          part : 'contentDetails',
-          id : 'UCMzabFudT_ntxlueP9R-3Vg',
-          key: 'AIzaSyBKfalwfLyyEC2uy-cH_ab5mXjNbKz5oAA'},
-          function(data) {
-            $.each( data.items, function( i, item ) {
-              playlists = ['PLzlG0L9jlhEOwdVv4nJZW6c_MCLbmfs4z', 'PLzlG0L9jlhEN3-GX9s6kAAt_kJcWWrAU1'];
-              playlists.forEach(function(pid) {
-                getVids(pid);
-              });
-            });
-          }
-        );
-      }
-      window.onload = loadVids;
-      
-      function getVids(pid){
-        $.get(
-          "https://www.googleapis.com/youtube/v3/playlistItems",{
-          part : 'snippet',
-          maxResults : 50,
-          playlistId : pid,
-          key: 'AIzaSyBKfalwfLyyEC2uy-cH_ab5mXjNbKz5oAA'},
-          function(data) {
-            var results;
-            $.each( data.items, function( i, item ) {
-              var fullDescription = item.snippet.description,
-                  description = fullDescription.substring(0, 160);
-
-              if (fullDescription.length > 160) {
-                description = description + '...';
-              }
-
-              results = '<a class="video" href="https://www.youtube.com/watch?v='+item.snippet.resourceId.videoId+'" data-lity="" data-lity-target="https://www.youtube.com/watch?v='+item.snippet.resourceId.videoId+'"><div class="thumbnail-wrap imported"><img src="'+ item.snippet.thumbnails.high.url +'"></div><h4>'+ item.snippet.title +'</h4><p>'+ description +'</p></a>';
-
-              $('#videos-grid').append(results);
-            });
-          }
-        );
-      }
-    </script>
 
     <h1>Videos</h1>
     <div id="videos-grid" class="grid">
@@ -105,4 +60,49 @@
   </section>
 </div>
 
-{{ partial "footer" . }}
+{{ end }}
+{{ define "page-scripts" }}
+<script>
+  $(document).ready(function(){
+    $.get(
+      "https://www.googleapis.com/youtube/v3/channels",{
+      part : 'contentDetails',
+      id : 'UCMzabFudT_ntxlueP9R-3Vg',
+      key: 'AIzaSyBKfalwfLyyEC2uy-cH_ab5mXjNbKz5oAA'},
+      function(data) {
+        $.each( data.items, function( i, item ) {
+          playlists = ['PLzlG0L9jlhEOwdVv4nJZW6c_MCLbmfs4z', 'PLzlG0L9jlhEN3-GX9s6kAAt_kJcWWrAU1'];
+          playlists.forEach(function(pid) {
+            getVids(pid);
+          });
+        });
+      }
+    );
+  });
+
+  function getVids(pid){
+    $.get(
+      "https://www.googleapis.com/youtube/v3/playlistItems",{
+      part : 'snippet',
+      maxResults : 50,
+      playlistId : pid,
+      key: 'AIzaSyBKfalwfLyyEC2uy-cH_ab5mXjNbKz5oAA'},
+      function(data) {
+        var results;
+        $.each( data.items, function( i, item ) {
+          var fullDescription = item.snippet.description,
+              description = fullDescription.substring(0, 160);
+
+          if (fullDescription.length > 160) {
+            description = description + '...';
+          }
+
+          results = '<a class="video" href="https://www.youtube.com/watch?v='+item.snippet.resourceId.videoId+'" data-lity="" data-lity-target="https://www.youtube.com/watch?v='+item.snippet.resourceId.videoId+'"><div class="thumbnail-wrap imported"><img src="'+ item.snippet.thumbnails.high.url +'"></div><h4>'+ item.snippet.title +'</h4><p>'+ description +'</p></a>';
+
+          $('#videos-grid').append(results);
+        });
+      }
+    );
+  }
+</script>
+{{ end }}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,10 +1,3 @@
 <footer>
   <p class="contained">Community chat on <a href="{{ .Site.Data.community.gitterurl }}" target="_blank" class="text-link">Gitter</a>. Site code on <a href="https://github.com/jamstack/jamstack.org">GitHub</a>. Pull Requests welcome!</p>
 </footer>
-
-<script src="/js/jquery-2.2.4.min.js"></script>
-<script src="/js/jquery.slicknav.min.js"></script>
-<script src="/js/lity.js"></script>
-<script src="/app.js"></script>
-</body>
-</html>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,24 +1,9 @@
-<!doctype html>
-<html>
-  <head>
-    <title>{{ .Site.Title }}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link type="image/x-icon" rel="shortcut icon" href="/img/favicon.ico">
-
-    {{ if or (eq .Title "Community") (eq .Title "Resources") }}
-      <script src="//assets.juicer.io/embed.js" type="text/javascript"></script>
-      <link href="//assets.juicer.io/embed.css" media="all" rel="stylesheet" type="text/css" />
-    {{ end }}
-
-    <link rel="stylesheet" href="/css/main.css"/>
-  </head>
-  <body>
-    <header id="header" class="on-{{ .Title | urlize }}">
-      <ul id="menu" class="contained">
-        <li class="logo"><a href="/" class="logo-link"><img src="/img/jamstack-full-logo.svg"/></a></li>
-        <li><a href="/best-practices" class="best-practices-link">Best Practices</a></li>
-        <li><a href="/examples" class="examples-link">Examples</a></li>
-        <li><a href="/resources" class="resources-link">Resources</a></li>
-        <li><a href="/community" class="community-link">Community</a></li>
-      </ul>
-    </header>
+<header id="header" class="on-{{ .Title | urlize }}">
+  <ul id="menu" class="contained">
+    <li class="logo"><a href="/" class="logo-link"><img src="/img/jamstack-full-logo.svg"/></a></li>
+    <li><a href="/best-practices" class="best-practices-link">Best Practices</a></li>
+    <li><a href="/examples" class="examples-link">Examples</a></li>
+    <li><a href="/resources" class="resources-link">Resources</a></li>
+    <li><a href="/community" class="community-link">Community</a></li>
+  </ul>
+</header>

--- a/site/layouts/partials/html-head.html
+++ b/site/layouts/partials/html-head.html
@@ -1,0 +1,12 @@
+<head>
+  <title>{{ .Site.Title }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link type="image/x-icon" rel="shortcut icon" href="/img/favicon.ico">
+
+  {{ if or (eq .Title "Community") (eq .Title "Resources") }}
+    <script src="//assets.juicer.io/embed.js" type="text/javascript"></script>
+    <link href="//assets.juicer.io/embed.css" media="all" rel="stylesheet" type="text/css" />
+  {{ end }}
+
+  <link rel="stylesheet" href="/css/main.css"/>
+</head>

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -1,0 +1,4 @@
+<script src="/js/jquery-2.2.4.min.js"></script>
+<script src="/js/jquery.slicknav.min.js"></script>
+<script src="/js/lity.js"></script>
+<script src="/app.js"></script>


### PR DESCRIPTION
Made fixes and changes to the Hugo layout structure for the site.

 - Created content as front matter markdown
 - Created default layouts (baseof) for the page type
 - Blocks (main, page-scripts) created for separation of html and scripts on a page
 ```html
{{ define "main" }}
{{ end }}
{{ define "page-scripts" }}
{{ end }}
```
 - separated partials for layout re-use
 - Fixed the quickfix for #87 to allow page scripts to follow linked scripts
 - Used the jQuery `$(document).ready` method of loading an init function now that structure allows

**Considerations**
Could easily move this structure to a theme now, so might want to theme this layout, but not required.