### PR TITLE
Add JAMstack website link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,5 @@ We actively welcome your pull requests!
 
 ## License
 
-By contributing to jamstack.org, you agree that your contributions will be licensed
+By contributing to [JAMstack](https://jamstack.org/), you agree that your contributions will be licensed
 under its [MIT license](LICENSE).


### PR DESCRIPTION
Instead of just referring to `jamstack.org`, it's a tad cleaner to refer to the actual name of the organisation and link to the referenced website as well.