### PR TITLE
Added the Seattle meetup link

### DIFF
--- a/site/data/community.yaml
+++ b/site/data/community.yaml
@@ -58,9 +58,8 @@ chapters:
     link: https://www.meetup.com/JAMstack-Bengaluru/
   - name: JAMstack Seattle
     artpath: /img/chapters/seattle-art.svg
-    btncopy: Coming Soon
-    link: #
-    teaser: true
+    btncopy: Join Now
+    link: https://www.meetup.com/jamstack-seattle/
   - name: JAMstack Philadelphia
     artpath: /img/chapters/philadelphia-art.svg
     btncopy: Coming Soon


### PR DESCRIPTION
This adds the link to the Seattle meetup using the existing assets.

Demo: https://deploy-preview-149--jamstack-site.netlify.com/community

<img width="309" alt="Seattle Meetup" src="https://user-images.githubusercontent.com/3411183/48919763-a0a52180-ee49-11e8-85df-97dfef40aea0.png">

