### PR TITLE
Removing Dallas from Community page 😞

### DIFF
--- a/site/data/community.yaml
+++ b/site/data/community.yaml
@@ -4,10 +4,6 @@ chapters:
     artpath: /img/chapters/sf-art.svg
     btncopy: Join Now
     link: https://www.meetup.com/jamstack-sf/
-  - name: JAMstack Dallas
-    artpath: /img/chapters/dallas-art.svg
-    btncopy: Join Now
-    link: https://www.meetup.com/jamstack-dallas/
   - name: JAMstack Austin
     artpath: /img/chapters/austin-art.svg
     btncopy: Join Now


### PR DESCRIPTION
The JAMstack Dallas meetup has disbanded and the meetup link 404s, so we should remove it for now.

Closes #150 

Signed-off-by: lesliecdubs <leslie@netlify.com>