### PR TITLE
remove philly meetup for inactivity

### DIFF
--- a/site/data/community.yaml
+++ b/site/data/community.yaml
@@ -59,11 +59,6 @@ chapters:
     artpath: /img/chapters/seattle-art.svg
     btncopy: Join Now
     link: https://www.meetup.com/jamstack-seattle/
-  - name: JAMstack Philadelphia
-    artpath: /img/chapters/philadelphia-art.svg
-    btncopy: Coming Soon
-    link: #
-    teaser: true
   - name: JAMstack Tokyo
     artpath: /img/chapters/tokyo-art.svg
     btncopy: Coming Soon


### PR DESCRIPTION
we don't know upon whose request we added philly to the list, and we have no information on who is doing anything there, so i am removing this meetup for now for inactivity.