### PR TITLE
Update the definition of "A" in JAMstack

### DIFF
--- a/site/data/definitions.yaml
+++ b/site/data/definitions.yaml
@@ -3,7 +3,7 @@ jamstack: "**JAMstack**: noun &#92;’jam-stak’&#92; <span><br></span>Modern w
 explanation: When we talk about "The Stack," we no longer talk about operating systems, specific web servers, backend programming languages, or databases.<br><br>The JAMstack is not about specific technologies. It's a new way of building websites and apps that delivers better performance, higher security, lower cost of scaling, and a better developer experience.
 
 javascript: "Any dynamic programming during the request/response cycle is handled by JavaScript, running entirely on the client. This could be any frontend framework, library, or even vanilla JavaScript."
-apis: "All server-side processes or database actions are abstracted into reusable APIs, accessed over HTTPS with JavaScript. These can be custom-built or leverage third-party services."
+apis: "All server-side processes or database actions are abstracted into reusable APIs, accessed over HTTPS. These can be custom-built or leverage third-party services."
 markup: "Templated markup should be prebuilt at deploy time, usually using a site generator for content sites, or a build tool for web apps.<br><br>[Want to see some examples?](/examples)"
 
 disqualifications:


### PR DESCRIPTION
Hi JAMstackers! ❤️ 

I'm sending this (very cheeky) PR because I feel that the existing definition of JAMstack is slightly misleading. The _A_ in the _JAM_ acronym is defined as:

> All server-side processes or database actions are abstracted into reusable APIs, accessed over HTTPS with **JavaScript**. These can be custom-built or leverage third-party services.

I see JavaScript as a requirement for all the client-side work, which is indeed a crucial part of the JAMstack architecture. But my interpretation is that the client-side interaction with APIs is captured in the _J_, and that the the _A_ refers to any server-side processing, which can be done with any technology stack and not necessarily JavaScript. I fear that phrasing it like this could induce people in error, making them think that their static site generators, serverless functions or any server-side processing must run on JavaScript/Node.js in order to qualify as a JAMstack project.

I apologise in advance if my interpretation is flawed. If so, please ignore this PR. ➡️🗑 

Thanks!