### PR TITLE
correct link for paris meetup, remove toulouse meetup link

### DIFF
--- a/site/data/community.yaml
+++ b/site/data/community.yaml
@@ -31,10 +31,6 @@ chapters:
     artpath: /img/chapters/berlin-illo.svg
     btncopy: Join Now
     link: https://www.meetup.com/JAMstack-Berlin/
-  - name: JAMstack Toulouse
-    artpath: /img/chapters/toulouse-illo.svg
-    btncopy: Join Now
-    link: https://www.meetup.com/JAMstack-Toulouse/
   - name: JAMstack Wrocław
     artpath: /img/chapters/wroclaw-illo.svg
     btncopy: Join Now
@@ -54,7 +50,7 @@ chapters:
   - name: JAMstack Paris
     artpath: /img/chapters/paris-art.svg
     btncopy: Join Now
-    link: https://www.meetup.com/fr-FR/JAMstack-paris/events/256464233/
+    link: https://www.meetup.com/fr-FR/JAMstack-paris/
   - name: JAMstack Seattle
     artpath: /img/chapters/seattle-art.svg
     btncopy: Join Now


### PR DESCRIPTION
Fix the link to the paris meetup, which pointed to an individual event, not the main page. Remove link to Toulouse, as apparently they have deleted their meetup account and it went to a 404.