### PR TITLE
Added a Code of Conduct for events

### DIFF
--- a/site/content/code-of-conduct.md
+++ b/site/content/code-of-conduct.md
@@ -1,0 +1,6 @@
+---
+type: page
+title: Code of Conduct
+url: "/code-of-conduct/"
+layout: "code-of-conduct"
+---

--- a/site/layouts/page/code-of-conduct.html
+++ b/site/layouts/page/code-of-conduct.html
@@ -1,0 +1,92 @@
+{{ define "main" }}
+<div class="community code-of-conduct">
+  <section class="hero">
+    <div class="contained">
+      <h1 class="community-headline">Event Code of Conduct</h1>
+    </div>
+  </section>
+  <div class="contained">
+    <article>
+      <p>
+        JAMstack events are about building and fostering a diverse, safe, and
+        inclusive community for individuals of all backgrounds and levels of
+        experience to learn, connect, and grow together.
+      </p>
+      <p>
+        Every person has their personal story that has shaped their unique
+        perspective. This can be a fascinating thing! Everyone you meet has the
+        potential to amaze you with the things they’ve done and the things they
+        know. However, it can also create misunderstandings, which can
+        potentially lead to conflict.
+      </p>
+      <p>
+        In order to mitigate conflict, and to create a more welcoming, safe
+        atmosphere, all attendees, sponsors, speakers, vendors, volunteers,
+        staff and organizers shall:
+      </p>
+      <h2>Be considerate</h2>
+      <p>
+        Approach your interactions with thoughtfulness and care. Recognize the
+        myriad differences between yourself and others, and that you may not
+        view the world through the same lens. Do not dismiss someone because
+        they have a different level of experience, are of a different
+        background, or have a difference of opinion. Be kind to others.
+      </p>
+      <h2>Be respectful</h2>
+      <p>
+        Disagreement is not an excuse for poor manners. We work together to
+        resolve conflict, assume good intentions and do our best to act in an
+        empathic fashion. We don’t allow frustration to turn into a personal
+        attack. A community where people feel uncomfortable or threatened is not
+        a productive one.
+      </p>
+    </article>
+    <article>
+      <h1>Anti-harassment policy</h1>
+      <p>
+        This event is dedicated to providing a harassment-free conference
+        experience for everyone, regardless of gender, gender identity and
+        expression, age, sexual orientation, disability, physical appearance,
+        body size, race, ethnicity, religion (or lack thereof), or technology
+        choices. We do not tolerate harassment of participants in any form.
+        Sexual language and imagery is not appropriate for any event venue,
+        including talks, workshops, parties, Twitter and other online media.
+        Event participants violating these rules may be sanctioned or expelled
+        from the event without a refund at the discretion of the event
+        organisers.
+      </p>
+      <p>
+        Sponsors should not use sexualized images, activities, or other
+        material. Booth staff (including volunteers) should not use sexualized
+        clothing/uniforms/costumes, or otherwise create a sexualized
+        environment.
+      </p>
+      <ul class="tools">
+        <li>
+          Verbal or written offensive comments related to gender, gender
+          identity and expression, sexual orientation, disability, physical
+          appearance, body size, race, age, or religion
+        </li>
+        <li>Sexual images in public spaces</li>
+        <li>Deliberate intimidation, stalking, or following</li>
+        <li>Harassing photography or recording</li>
+        <li>Sustained disruption of talks or other events</li>
+        <li>Inappropriate physical contact</li>
+        <li>Unwelcome sexual attention</li>
+        <li>Advocating for, or encouraging, any of the above behaviour</li>
+      </ul>
+      <h2>Bathroom policy</h2>
+      <p>
+        Diversity and self-expression are important in our world - both at this
+        event and beyond. Therefore, we encourage all attendees at the
+        conference/event to use the bathroom they feel most comfortable in,
+        regardless of gender expression. Should you feel inclined to question
+        someone’s bathroom choice, please don’t - we feel sure they know quite
+        well where they belong. If you witness someone being made to feel
+        unwelcome, or someone makes you feel unwelcome while using the
+        facilities, please reach out to an event organizer so we can assist you.
+      </p>
+    </article>
+  </div>
+</div>
+{{ end }}

--- a/site/layouts/page/community.html
+++ b/site/layouts/page/community.html
@@ -4,6 +4,9 @@
   <section class="hero">
     <div class="contained">
       <h1 class="community-headline">Join your local JAMstack Chapter.</h1>
+      <span class="community-headline-link">
+        Need a code of conduct for your event? <a href="/code-of-conduct">Look no further.
+      </span>
     </div>
   </section>
 

--- a/src/css/imports/base.css
+++ b/src/css/imports/base.css
@@ -79,7 +79,8 @@ h4 {
   }
 }
 
-p {
+p,
+li {
   font-size: 14px;
   line-height: $small;
 

--- a/src/css/imports/community.css
+++ b/src/css/imports/community.css
@@ -1,5 +1,4 @@
 .community {
-
   h1 {
     line-height: 32px;
 
@@ -20,6 +19,12 @@
       padding: 160px 0 calc($xl * 2) 0;
       margin-bottom: -$xl;
     }
+  }
+
+  .community-headline-link {
+    display: inline-block;
+    font-size: 18px;
+    margin: 10px 0 20px;
   }
 
   .grid {
@@ -52,7 +57,6 @@
         margin: 0 3% 0 0;
         width: 44%;
       }
-
     }
 
     .event-card {
@@ -192,7 +196,7 @@
 
     @media screen and (min-width: $tablet) {
       margin: $xl auto $large auto;
-      }
+    }
 
     > h1 {
       margin-bottom: 32px;
@@ -357,6 +361,20 @@
       padding: $tiny $small;
       min-width: $xxl;
       text-align: center;
+    }
+  }
+
+  &.code-of-conduct {
+    text-align: left;
+    padding-bottom: 100px;
+
+    h1,
+    h2 {
+      margin-top: 1.5em;
+    }
+
+    .contained {
+      max-width: 960px;
     }
   }
 }

--- a/src/css/imports/examples.css
+++ b/src/css/imports/examples.css
@@ -134,7 +134,10 @@
     }
 
     li {
+      font-size: 16px;
       font-weight: $regular;
+      line-height: normal;
+
       &:before {
         content: '• ';
       }


### PR DESCRIPTION
This PR adds a /code-of-conduct page.

The text has been shamelessly taken from the [JAMstack_conf](https://jamstackconf.com/nyc/code-of-conduct/) website and adapted a little to use the term "event" instead of "conference".

I didn't add a link in the nav, but I could do that if y'all think it's appropriate.

Feedback welcome!

**Demo**:
* https://deploy-preview-186--jamstack-site.netlify.com/code-of-conduct/
* https://deploy-preview-186--jamstack-site.netlify.com/community