### PR TITLE
Add JAMstack_conf banner to all pages

### DIFF
--- a/site/layouts/page/baseof.html
+++ b/site/layouts/page/baseof.html
@@ -2,6 +2,7 @@
 <html>
   {{ partial "html-head" . }}
   <body>
+    {{ partial "promo" . }}
     {{ partial "header" . }}
     {{ block "main" . }}{{ end }}
     {{ partial "footer" . }}


### PR DESCRIPTION
When we introduced the JAMstack_conf banner, we only had it on the homepage, but kept the margins of the header, leaving a "hole".

This PR only makes sure the banner is visible in all pages.

## Before
![Screenshot 2019-05-26 13 48 55](https://user-images.githubusercontent.com/2281080/58381403-0de26c80-7fbd-11e9-91e4-635499ff664c.png)

## After
![Safari 2019-05-26 at 13 49 27@2x](https://user-images.githubusercontent.com/2281080/58381407-189d0180-7fbd-11e9-9862-87aac6ba2538.png)
