### PR TITLE
chore: add ref query params for external links

### DIFF
--- a/site/layouts/page/examples.html
+++ b/site/layouts/page/examples.html
@@ -12,7 +12,7 @@
     </div>
     <div class="grid">
       {{ range .Site.Data.examples.examples }}
-      <a class="example" href="{{ .link }}?ref=jamstack.org" target="_blank">
+      <a class="example" href="{{ .link }}?ref=jamstack.org" rel="noopener" target="_blank">
         <div class="browser">
           <div class="controls">•••</div>
         </div>

--- a/site/layouts/page/examples.html
+++ b/site/layouts/page/examples.html
@@ -12,7 +12,7 @@
     </div>
     <div class="grid">
       {{ range .Site.Data.examples.examples }}
-      <a class="example" href="{{ .link }}" target="_blank">
+      <a class="example" href="{{ .link }}?ref=jamstack.org" target="_blank">
         <div class="browser">
           <div class="controls">•••</div>
         </div>

--- a/site/layouts/page/resources.html
+++ b/site/layouts/page/resources.html
@@ -44,7 +44,7 @@
     <ul class="articles-list contained">
       {{ range .Site.Data.resources.articles }}
       <li>
-        <a href="{{ .link }}" target="_blank">
+        <a href="{{ .link }}?ref=jamstack.org" rel="noopener" target="_blank">
           <h3>{{ .title }}</h3>
           <span>→</span>
         </a>


### PR DESCRIPTION
Hey 👋🏻

I thought that adding a query parameter would help identifying traffic to outbound links, which are provided as resources and examples. :)

Instead of `https://foobar.com/` links would point to `https://foobar.com/?ref=jamstack.org` (or similar).