### PR TITLE
Randomize the order of example sites on each load

### DIFF
--- a/site/layouts/page/examples.html
+++ b/site/layouts/page/examples.html
@@ -26,6 +26,20 @@
       </a>
       {{ end }}
     </div>
+    <script>
+      (function() {
+        var examples = document.getElementsByClassName("example");
+        var l = examples.length;
+        var order = Array.apply(null, {length: l}).map(Number.call, Number);
+        while (l--) {
+          var newPos = Math.floor(Math.random() * (l + 1));
+          var temp = order[l];
+          order[l] = order[newPos];
+          order[newPos] = temp;
+        }
+        for (var i = 0, j = examples.length; i < j; ++i) examples[i].style.order = order[i];
+      })();
+    </script>
   </div>
 </div>
 {{ end }}

--- a/src/css/imports/examples.css
+++ b/src/css/imports/examples.css
@@ -39,6 +39,7 @@
   .grid {
     display: flex;
     flex-wrap: wrap;
+    justify-content: space-between;
   }
 
   .example {
@@ -50,18 +51,6 @@
 
     @media screen and (min-width: $desktop) {
       width: 30%;
-    }
-
-    &:nth-child(2n) {
-      @media screen and (min-width: $tablet) and (max-width: 959px) {
-        margin: 0 0 0 4%;
-      }
-    }
-
-    &:nth-child(3n - 1) {
-      @media screen and (min-width: $desktop) {
-        margin: 0 5%;
-      }
     }
 
     &:hover {


### PR DESCRIPTION
I was thinking of making a PR to add a site to the examples page, but I realised I wasn't sure of the etiquette of where to place it. Anyway, I figured if the order of the examples is randomized on every page load, it wouldn't matter! I also figured it might be a nice way of presenting the examples, as I doubt many people scroll all the way down the page.

I wrote a function in vanilla ES5 to [randomize](https://en.wikipedia.org/wiki/Fisher–Yates_shuffle) the layout via flexbox's `order` property. That also meant I had to replace the media queries setting the margin of the examples with the `justify-content` line, which works exactly the same.