### PR TITLE
Add noopener noreferrer rel to projects and articles links

### DIFF
--- a/site/layouts/page/examples.html
+++ b/site/layouts/page/examples.html
@@ -12,7 +12,7 @@
     </div>
     <div class="grid">
       {{ range .Site.Data.examples.examples }}
-      <a class="example" href="{{ .link }}" target="_blank">
+      <a class="example" href="{{ .link }}" rel="noopener noreferrer" target="_blank">
         <div class="browser">
           <div class="controls">•••</div>
         </div>

--- a/site/layouts/page/resources.html
+++ b/site/layouts/page/resources.html
@@ -25,18 +25,18 @@
   </section>
 
   <section class="contained">
-  	<h1>Modern Web Development on the Jamstack eBook</h1>
-  	<p>New Techniques for Ultra Fast Sites and Web Applications by Mathias Biilmann & Phil Hawksworth - <a href="https://www.netlify.com/oreilly-jamstack/" target="_blank" class="text-link">Get a free copy of eBook</a></p>
+    <h1>Modern Web Development on the Jamstack eBook</h1>
+    <p>New Techniques for Ultra Fast Sites and Web Applications by Mathias Biilmann & Phil Hawksworth - <a href="https://www.netlify.com/oreilly-jamstack/" target="_blank" class="text-link">Get a free copy of eBook</a></p>
 
-  	<p>
-  		<strong>• Methods for solving web development challenges — from architecture to microservices</strong>
-  		<strong>• Why the Jamstack’s cleaner architecture eliminates the need to scale sites up front</strong>
-  		<strong>• Best practices for adopting the Jamstack in your organization</strong>
-  	</p>
+    <p>
+      <strong>• Methods for solving web development challenges — from architecture to microservices</strong>
+      <strong>• Why the Jamstack’s cleaner architecture eliminates the need to scale sites up front</strong>
+      <strong>• Best practices for adopting the Jamstack in your organization</strong>
+    </p>
 
-  	<a href="https://www.netlify.com/oreilly-jamstack/" target="_blank" class="text-link">
-  		<h2>Download the Jamstack eBook →</h2>
-  	</a>
+    <a href="https://www.netlify.com/oreilly-jamstack/" target="_blank" class="text-link">
+      <h2>Download the Jamstack eBook →</h2>
+    </a>
   </section>
 
   <section class="articles">
@@ -44,7 +44,7 @@
     <ul class="articles-list contained">
       {{ range .Site.Data.resources.articles }}
       <li>
-        <a href="{{ .link }}" target="_blank">
+        <a href="{{ .link }}" rel="noopener noreferrer" target="_blank">
           <h3>{{ .title }}</h3>
           <span>→</span>
         </a>


### PR DESCRIPTION
We should use rel="noopener noreferrer" with links that containing target="_blank" as a precaution against reverse tabnabbing. 

FF does not support "noopener" so we should use both of this - noopener and noreferrer