### PR TITLE
Update accessible names for images

### DIFF
--- a/site/data/bestpractices.yaml
+++ b/site/data/bestpractices.yaml
@@ -1,5 +1,8 @@
 ---
 bestpractices:
+  art:
+    path: /img/thumbs-up.svg
+    alt: Best Practice
   - title: Entire Project on a CDN
     description: Because Jamstack projects don’t rely on server-side code, they can be distributed instead of living on a single server. Serving directly from a CDN unlocks speeds and performance that can't be beat. The more of your app you can push to the edge, the better the user experience.
   - title: Everything Lives in Git

--- a/site/data/community.yaml
+++ b/site/data/community.yaml
@@ -140,7 +140,9 @@ slackurl: https://Jamstack.org/slack
 forumurl: https://community.netlify.com
 
 bottomcta:
-  artpath: /img/chapters/meetup-map.svg
+  art:
+    path: /img/chapters/meetup-map.svg
+    alt: World map with markers around California, Texas, and Great Britain
   headline: Start a Jamstack Meetup
   ctacopy: Contact Us
   ctalink: mailto:community@netlify.com

--- a/site/data/conduct.yaml
+++ b/site/data/conduct.yaml
@@ -1,5 +1,8 @@
 ---
 mainpoints:
+  art:
+    path: /img/thumbs-up.svg
+    alt: Main point
   - title: Be considerate
     description: Approach your interactions with thoughtfulness and care. Do not dismiss someone because they have a different level of experience, are of a different background, or have a difference of opinion. Be kind to others.
   - title: Be respectful

--- a/site/layouts/page/best-practices.html
+++ b/site/layouts/page/best-practices.html
@@ -6,7 +6,7 @@
     <div class="grid">
       {{ range .Site.Data.bestpractices.bestpractices }}
         <div class="best-practice">
-          <h4><img src="/img/thumbs-up.svg" /> {{ .title }}</h4>
+          <h4><img src="{{ .art.path }}" alt="{{ .art.alt }}" /> {{ .title }}</h4>
           <p>{{ .description | markdownify }}</p>
         </div>
       {{ end }}

--- a/site/layouts/page/community.html
+++ b/site/layouts/page/community.html
@@ -11,7 +11,7 @@
     <div class="grid">
       {{ range .Site.Data.community.chapters }}
         <a class="chapter {{ .name | urlize }}" href="{{ .link }}">
-          <img src="{{ .artpath }}" class="art"/>
+          <img src="{{ .artpath }}" class="art" role="presentation" />
           <h1>{{ .name }}</h1>
           <div class="button{{ if .teaser }} greyed{{ end }}">{{ .btncopy }}</div>
         </a>
@@ -110,14 +110,14 @@
 
   <div class="bottom-cta">
     <div class="contained">
-      <img src="{{ .Site.Data.community.bottomcta.artpath }}" class="art"/>
+      <img src="{{ .Site.Data.community.bottomcta.art.path }}" class="art" alt="{{ .Site.Data.community.bottomcta.art.alt }}" />
       <h1>{{ .Site.Data.community.bottomcta.headline }}</h1>
       <a href="{{ .Site.Data.community.bottomcta.ctalink }}" class="button">{{ .Site.Data.community.bottomcta.ctacopy }}</a>
     </div>
   </div>
 
   <section class="chatter">
-    <h1>Spread the JAM by tweeting <span><img src="/img/twitter.svg"/>#Jamstack</span></h1>
+    <h1>Spread the JAM by tweeting <span><img src="/img/twitter.svg" role="presentation" />#Jamstack</span></h1>
     <div class="tweets">
       <div class="contained">
         <ul class="juicer-feed" data-feed-id="jamstack" data-pages="1" data-overlay="false" data-per="3"></ul>

--- a/site/layouts/page/conduct.html
+++ b/site/layouts/page/conduct.html
@@ -7,7 +7,7 @@
     <div class="grid">
       {{ range .Site.Data.conduct.mainpoints }}
         <div class="best-practice">
-          <h4><img src="/img/thumbs-up.svg" /> {{ .title }}</h4>
+          <h4><img src="{{ .art.path }}" alt="{{ .art.alt }}" /> {{ .title }}</h4>
           <p>{{ .description | markdownify }}</p>
         </div>
       {{ end }}

--- a/site/layouts/page/examples.html
+++ b/site/layouts/page/examples.html
@@ -16,7 +16,7 @@
         <div class="browser">
           <div class="controls">•••</div>
         </div>
-        <img src="{{ .thumbnailurl }}" />
+        <img src="{{ .thumbnailurl }}" role="presentation" />
         <h1>{{ .title }}</h1>
         <ul class="tools">
           {{ range .tools }}

--- a/site/layouts/page/resources.html
+++ b/site/layouts/page/resources.html
@@ -15,7 +15,7 @@
       {{ range .Site.Data.resources.videos }}
       <a class="video" href="{{ .link }}" data-lity data-lity-target="{{ .link }}">
         <div class="thumbnail-wrap">
-          <img src="{{ .thumbnailurl }}" />
+          <img src="{{ .thumbnailurl }}" role="presentation" />
         </div>
         <h4>{{ .title }}</h4>
         <p>{{ .description }}</p>
@@ -56,7 +56,7 @@
   <section class="podcasts contained">
     <div class="podcast-promo">
       <div class="cta">
-        <img class="jamstack-radio" src="/img/jamstack-knockout.svg" />
+        <img class="jamstack-radio" src="/img/jamstack-knockout.svg" role="presentation" />
         <a href="https://www.netlify.com/tags/podcast" class="button green">View All Podcasts →</a>
       </div>
       <div class="teaser">
@@ -68,7 +68,8 @@
   </section>
 
   <section class="chatter">
-    <h1>Spread the JAM by tweeting <span><img src="/img/twitter.svg" />#Jamstack</span></h1>
+    <h1>Spread the JAM by tweeting <span><img src="/img/twitter.svg" role="presentation" />#Jamstack</span></h1>
+    le=
     <div class="tweets">
       <div class="contained">
         <ul class="juicer-feed" data-feed-id="jamstack" data-pages="1" data-overlay="false" data-per="3"></ul>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <header id="header" class="on-{{ .Title | urlize }}">
   <ul id="menu" class="contained">
-    <li class="logo"><a href="/" class="logo-link"><img src="/img/jamstack-full-logo.svg"/></a></li>
+    <li class="logo"><a href="/" class="logo-link"><img src="/img/jamstack-full-logo.svg" alt="Home" /></a></li>
     <li><a href="/best-practices" class="best-practices-link">Best Practices</a></li>
     <li><a href="/examples" class="examples-link">Examples</a></li>
     <li><a href="/resources" class="resources-link">Resources</a></li>


### PR DESCRIPTION
[Fixes #365]

- Add alternative text where the image adds helpful context.
- Set the role at presentation otherwise to remove the image from the AOM.
- Used [AccessLint](https://github.com/apps/accesslint) internals to find the issues.