### PR TITLE
Rename ZEIT Now -> Vercel.

### DIFF
--- a/src/site/_data/examples/smokeyfro.yaml
+++ b/src/site/_data/examples/smokeyfro.yaml
@@ -7,7 +7,7 @@ thumbnailurl: /img/examples/smokeyfro.jpg
 tools:
   - Vue
   - Gridsome
-  - Zeit Now
+  - Vercel
   - GitHub
   - Ghost
   - Cockpit


### PR DESCRIPTION
Replaces https://github.com/jamstack/jamstack.org/pull/335. ZEIT was rebranded to Vercel. Updates this to example to reflect the name change.

