### PR TITLE
Fixes for GitHub API rate limits

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,6 +37,8 @@
   status = 404
 
 
+[[plugins]]
+  package = "./plugins/keep-dot-cache-folder"
 
 # Config for the Netlify Build Plugin: netlify-plugin-minify-html
 [[plugins]]

--- a/plugins/keep-dot-cache-folder/index.js
+++ b/plugins/keep-dot-cache-folder/index.js
@@ -1,0 +1,15 @@
+module.exports = {
+  // Restore file/directory cached in previous builds.
+  // Does not do anything if:
+  //  - the file/directory already exists locally
+  //  - the file/directory has not been cached yet
+  async onPreBuild({ utils }) {
+    await utils.cache.restore('./.cache');
+  },
+  // Cache file/directory for future builds.
+  // Does not do anything if:
+  //  - the file/directory does not exist locally
+  async onPostBuild({ utils }) {
+    await utils.cache.save('./.cache');
+  }
+};

--- a/plugins/keep-dot-cache-folder/manifest.yml
+++ b/plugins/keep-dot-cache-folder/manifest.yml
@@ -1,0 +1,1 @@
+name: keep-dot-cache-folder

--- a/src/site/_data/github.js
+++ b/src/site/_data/github.js
@@ -69,7 +69,10 @@ async function githubRequest(user, repo) {
   try {
     req = await CacheAsset(url, opts);
     if(req.errors && req.errors.length) {
-      console.log( "Error", req.errors );
+      console.log( "GitHub Data Source Error from API", req.errors );
+      if(req.errors.filter(e => e.type === "RATE_LIMITED").length > 0) {
+        throw new Error("Failing the build due to GitHub API rate limiting.");
+      }
       return errorData;
     }
 
@@ -79,7 +82,8 @@ async function githubRequest(user, repo) {
       issues: req.data.repository.issues.totalCount,
     }
   } catch(e) {
-    console.log( "Error", e );
+    console.log( "GitHub Data Source Error", e );
+
     return errorData;
   }
 }


### PR DESCRIPTION
1. Keep the `.cache` folder around to reduce API requests (once per day)
2. Fail the build if it hits an API error from GitHub for rate limiting (prevents production builds from deploying with missing data)