### PR TITLE
Fix 2 typos for CDN definition in glossary

### DIFF
--- a/src/site/_data/glossary.yaml
+++ b/src/site/_data/glossary.yaml
@@ -1,6 +1,6 @@
 - term: 'CDN (Content Delivery Network)'
   id: 'cdn'
-  definition: 'A distributed network optimized for serving assets to users. By being geographically distributed, a CDN can provide redundancy adn also improve delovery performance as a result of servicing requests from the infrastructure closest to the user making the request.'
+  definition: 'A distributed network optimized for serving assets to users. By being geographically distributed, a CDN can provide redundancy and also improve delivery performance as a result of servicing requests from the infrastructure closest to the user making the request.'
 
 - term: 'Edge Network'
   id: 'edge-network'


### PR DESCRIPTION
This PR is to fix 2 typos for CDN definition in the glossary.

