### PR TITLE
Fix word in what-is-jamstack

### DIFF
--- a/src/site/what-is-jamstack.njk
+++ b/src/site/what-is-jamstack.njk
@@ -19,7 +19,7 @@ layout: layouts/base.njk
 <section>
   <h2>Pre-rendering</h2>
   <p>
-    With Jamstack, the entire front end is prebuilt into highly optimized static pages and assets during a build process. This process of pre-rending results in sites which can be served directly from a <a href="/glossary/cdn/">CDN</a>, reducing the cost, complexity and risk, of dynamic servers as cirticial infrastructure.
+    With Jamstack, the entire front end is prebuilt into highly optimized static pages and assets during a build process. This process of pre-rending results in sites which can be served directly from a <a href="/glossary/cdn/">CDN</a>, reducing the cost, complexity and risk, of dynamic servers as critical infrastructure.
   </p>
   <p>
     With so many popular tools for generating sites</a>, like <a href="/generators/gatsby/">Gatsby</a>, <a href="/generators/hugo/">Hugo</a>, <a href="/generators/jekyll/">Jekyll</a>, <a href="/generators/eleventy/">Eleventy</a>, <a href="/generators/next/">NextJS</a>, <a href="/generators/">and very many more</a>, many web developers are already familiar with the tools needed to become productive Jamstack developers.


### PR DESCRIPTION
Replaced `cirticial` with `critical`. 