### PR TITLE
Various typo fixes

### DIFF
--- a/src/site/_data/glossary.yaml
+++ b/src/site/_data/glossary.yaml
@@ -33,7 +33,7 @@
 
 - term: 'Decoupling'
   id: 'decoupling'
-  definition: 'Decoupling is the process of creating a clean separation between systems or services. By decoupling the services needed to operate a site, each component part can become easier to reason about, can by independently swapped out or upgraded, and can be designated the purview of dedicated specialists either within an organization, or as a third party.'
+  definition: 'Decoupling is the process of creating a clean separation between systems or services. By decoupling the services needed to operate a site, each component part can become easier to reason about, can be independently swapped out or upgraded, and can be designated the purview of dedicated specialists either within an organization, or as a third party.'
 
 - term: 'Dynamic server'
   id: 'dynamic-server'

--- a/src/site/_data/glossary.yaml
+++ b/src/site/_data/glossary.yaml
@@ -33,7 +33,7 @@
 
 - term: 'Decoupling'
   id: 'decoupling'
-  definition: 'Decoupling is the process of creating a clean separation between systems or services. By decoupling the services needed to operate a site, each component part can become easier to reason about, can by independantly swapped out or upgraded, and can be designated the purvue of dedicated specialsts either within an organisation, or as a third party.'
+  definition: 'Decoupling is the process of creating a clean separation between systems or services. By decoupling the services needed to operate a site, each component part can become easier to reason about, can by independently swapped out or upgraded, and can be designated the purview of dedicated specialists either within an organization, or as a third party.'
 
 - term: 'Dynamic server'
   id: 'dynamic-server'

--- a/src/site/what-is-jamstack.njk
+++ b/src/site/what-is-jamstack.njk
@@ -37,7 +37,7 @@ layout: layouts/base.njk
     The thriving <a href="/glossary/api-economy/">API economy</a> has become a significant enabler for Jamstack sites. The ability to leverage domain experts who offer their products and service via APIs has allowed teams to build for more complex applications than if they were to take on the risk and burden of such capabilities themselves. Now we can outsource things like authentication and identity, payments, content management, data services, search, and much more.
     </p>
   <p>
-    Jamstack sites might utilize such services at build time, and also at run time directly from the browser via JavaScript. And the clean <a href="/glossary/decoupling/">decoupling</a> of these services allows for greater portability and flexibility, as well as significanlty reduced risk.
+    Jamstack sites might utilise such services at build time, and also at run time directly from the browser via JavaScript. And the clean <a href="/glossary/decoupling/">decoupling</a> of these services allows for greater portability and flexibility, as well as significanlty reduced risk.
   </p>
 </section>
 <section class="mb-20 pb-20 border-gray-400 border-b ">

--- a/src/site/what-is-jamstack.njk
+++ b/src/site/what-is-jamstack.njk
@@ -37,7 +37,7 @@ layout: layouts/base.njk
     The thriving <a href="/glossary/api-economy/">API economy</a> has become a significant enabler for Jamstack sites. The ability to leverage domain experts who offer their products and service via APIs has allowed teams to build for more complex applications than if they were to take on the risk and burden of such capabilities themselves. Now we can outsource things like authentication and identity, payments, content management, data services, search, and much more.
     </p>
   <p>
-    Jamstack sites might utilise such services at build time, and also at run time directly from the browser via JavaScript. And the clean <a href="/glossary/decoupling/">decoupling</a> of these services allows for greater portability and flexibility, as well as significanlty reduced risk.
+    Jamstack sites might utilize such services at build time, and also at run time directly from the browser via JavaScript. And the clean <a href="/glossary/decoupling/">decoupling</a> of these services allows for greater portability and flexibility, as well as significanlty reduced risk.
   </p>
 </section>
 <section class="mb-20 pb-20 border-gray-400 border-b ">


### PR DESCRIPTION
Fix typos in the `Decoupling` glossary page.

Fixes #429, along with a couple other typos. 
