### PR TITLE
Fix Deploy to Netlify button

### DIFF
--- a/src/site/_includes/layouts/tool.njk
+++ b/src/site/_includes/layouts/tool.njk
@@ -89,7 +89,7 @@ layout: layouts/base.njk
   
   
   {% if startertemplaterepo %}
-  <a href="https://app.netlify.com/start/deploy?repository={{ startertemplaterepo}}" class="inline-block my-8 px-4 py-3 text-gray-700 bg-white rounded-lg text-center md:text-lg whitespace-no-wrap border-t">
+  <a href="https://app.netlify.com/start/deploy?repository={{ startertemplaterepo }}" class="inline-block my-8 px-4 py-3 text-gray-700 bg-white rounded-lg text-center md:text-lg whitespace-no-wrap border-t">
     <svg role="img" aria-hidden="true" focusable="false" width="30" height="30" viewBox="0 0 40 40" class="inline-block mr-1" fill="#36b0bb"><use xlink:href="#logo-netlify-gem"/></svg>
     Deploy to Netlify
   </a>

--- a/src/site/generators/20ful.md
+++ b/src/site/generators/20ful.md
@@ -17,7 +17,7 @@ templates:
   - Sass
   - Stylus
 description: Universal static site generator
-startertemplaterepo: punund/20ful-example
+startertemplaterepo: https://github.com/punund/20ful-example
 ---
 
 Static site generator that includes preprocessors of HTML, CSS, and JavaScript.  Written in LiveScript. Features navigation and asset cache busting.  Controlled

--- a/src/site/generators/abell.md
+++ b/src/site/generators/abell.md
@@ -10,7 +10,7 @@ templates:
   - Abell
 description: A JavaScript based static-site-generator to help you create JSON, Markdown, or static-data based websites.
 twitter: AbellLand
-startertemplaterepo: abelljs/abell-starter-minima
+startertemplaterepo: https://github.com/abelljs/abell-starter-minima
 ---
 
 Abell is a Node.js based static-site-generator to help you create JSON, Markdown, or static-data based websites. 

--- a/src/site/generators/blogc.md
+++ b/src/site/generators/blogc.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Custom
 description: A blog compiler.
-startertemplaterepo: blogc/blogc-netlify
+startertemplaterepo: https://github.com/blogc/blogc-netlify
 ---
 
 blogc is a blog compiler. It converts source files and templates into blog/website resources. It is designed to be used with `make` or any other similar build tool. It is also stateless and idempotent, no state is shared between blogc binary calls.

--- a/src/site/generators/cactus.md
+++ b/src/site/generators/cactus.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Django
 description: Static site generator for designers.
-startertemplaterepo: netlify-templates/cactus-base
+startertemplaterepo: https://github.com/netlify-templates/cactus-base
 ---
 
 Cactus is a simple but powerful [static website generator](https://davidwalsh.name/introduction-static-site-generators) using Python and the [Django template system](http://docs.djangoproject.com/en/dev/topics/templates/). Cactus also makes it easy to develop locally and deploy your site to S3 directly. It works great for company, portfolio, personal, support websites and blogs.

--- a/src/site/generators/cecil.md
+++ b/src/site/generators/cecil.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Twig
 description: Your content driven static site generator.
-startertemplaterepo: Cecilapp/the-butler
+startertemplaterepo: https://github.com/Cecilapp/the-butler
 twitter: Cecil_Static
 ---
 

--- a/src/site/generators/cmints.md
+++ b/src/site/generators/cmints.md
@@ -9,7 +9,7 @@ license:
 templates:
   - EJS
 description: CMS and Static Site Generator for single and multi-language websites creation.
-startertemplaterepo: cmints/multi-lang-starter
+startertemplaterepo: https://github.com/cmints/multi-lang-starter
 ---
 
 [CMintS](https://cmints.io/) is a CMS and Static Site Generator for single and

--- a/src/site/generators/cuttlebelle.md
+++ b/src/site/generators/cuttlebelle.md
@@ -9,7 +9,7 @@ license:
 templates:
   - React
 description: The react static site generator that separates editing and code concerns
-startertemplaterepo: cuttlebelle/website
+startertemplaterepo: https://github.com/cuttlebelle/website
 ---
 
 > The react static site generator that separates editing and code concerns

--- a/src/site/generators/docusaurus.md
+++ b/src/site/generators/docusaurus.md
@@ -10,7 +10,7 @@ templates:
   - React
   - Markdown
 description: 'Build optimized websites quickly, focus on your content'
-startertemplaterepo: anishkny/docusaurus-base
+startertemplaterepo: https://github.com/anishkny/docusaurus-base
 twitter: docusaurus
 ---
 

--- a/src/site/generators/dssg.md
+++ b/src/site/generators/dssg.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Mustache
 description: A static site generator with a different approach
-startertemplaterepo: kambrium/dssg-example
+startertemplaterepo: https://github.com/kambrium/dssg-example
 ---
 
 Unlike other static site generators, DSSG doesn't differentiate between front matter and a content section in its content files. This makes it very easy to create web pages based on templates with multiple content sections.

--- a/src/site/generators/eleventy.md
+++ b/src/site/generators/eleventy.md
@@ -18,7 +18,7 @@ templates:
   - HTML
   - Markdown
 description: A simpler static site generator
-startertemplaterepo: 11ty/eleventy-base-blog
+startertemplaterepo: https://github.com/11ty/eleventy-base-blog
 twitter: eleven_ty
 ---
 

--- a/src/site/generators/elm-pages.md
+++ b/src/site/generators/elm-pages.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Elm
 description: Build fast, modern sites with Elm's delightful type system to help you! 📚
-startertemplaterepo: dillonkearns/elm-pages-starter
+startertemplaterepo: https://github.com/dillonkearns/elm-pages-starter
 twitter: elm_pages
 ---
 

--- a/src/site/generators/elm-starter.md
+++ b/src/site/generators/elm-starter.md
@@ -8,7 +8,7 @@ license:
   - BSD-3-Clause
 templates:
   - Elm
-startertemplaterepo: lucamug/elm-starter
+startertemplaterepo: https://github.com/lucamug/elm-starter
 description: An Elm-based bootstrapper for Elm applications that supports server side rendering
 ---
 

--- a/src/site/generators/empress-blog.md
+++ b/src/site/generators/empress-blog.md
@@ -10,7 +10,7 @@ templates:
   - Ember
   - Markdown
 description: Fully-functional, SEO friendly static site implementation of a blog system built on Ember
-startertemplaterepo: empress/empress-blog-netlify-casper-template
+startertemplaterepo: https://github.com/empress/empress-blog-netlify-casper-template
 ---
 
 This project is designed to be a fully-functional, static site implementation of a blog system that is mostly compatible with [Ghost](https://ghost.org/) and is built on EmberJS with fully working out of the box SEO friendly output.

--- a/src/site/generators/endurojs.md
+++ b/src/site/generators/endurojs.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Handlebars
 description: 'Minimalistic, lean & mean, node.js static page generator'
-startertemplaterepo: gottwik/enduro_mirror
+startertemplaterepo: https://github.com/gottwik/enduro_mirror
 ---
 
 ## Built for speed

--- a/src/site/generators/gatsby.md
+++ b/src/site/generators/gatsby.md
@@ -9,7 +9,7 @@ license:
 templates:
   - React
 description: Build blazing fast, modern apps and websites with React
-startertemplaterepo: gatsbyjs/gatsby-starter-default
+startertemplaterepo: https://github.com/gatsbyjs/gatsby-starter-default
 twitter: gatsbyjs
 ---
 

--- a/src/site/generators/gridsome.md
+++ b/src/site/generators/gridsome.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Vue
 description: Build blazing fast websites for any CMS or data with Vue.js
-startertemplaterepo: gridsome/gridsome-starter-default
+startertemplaterepo: https://github.com/gridsome/gridsome-starter-default
 twitter: gridsome
 ---
 

--- a/src/site/generators/gssg.md
+++ b/src/site/generators/gssg.md
@@ -10,7 +10,7 @@ templates:
   - HTML
 description: This is a Generic Static Site Generator, It is written in JavaScript, It can be used to create static websites
 twitter: Generic_SSG
-startertemplaterepo: theabbie/Generic-Static-Site-Generator
+startertemplaterepo: https://github.com/theabbie/Generic-Static-Site-Generator
 ---
 
 # Generic Static Site Generator

--- a/src/site/generators/hepek.md
+++ b/src/site/generators/hepek.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Scala
 description: Render Scala objects into files
-startertemplaterepo: sake92/hepek-starter
+startertemplaterepo: https://github.com/sake92/hepek-starter
 ---
 
 Hepek is a tool that turns Scala `object`s into files.  

--- a/src/site/generators/hexo.md
+++ b/src/site/generators/hexo.md
@@ -18,7 +18,7 @@ templates:
   - Marko
 description: 'Hexo is a fast, simple and powerful blog framework.'
 twitter: hexojs
-startertemplaterepo: hexojs/hexo-starter
+startertemplaterepo: https://github.com/hexojs/hexo-starter
 ---
 
 A fast, simple & powerful blog framework, powered by [Node.js](https://nodejs.org) and [NPM](https://www.npmjs.com/).

--- a/src/site/generators/hubpress.md
+++ b/src/site/generators/hubpress.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Handlebars
 description: A web application to build your Blog on GitHub.
-startertemplaterepo: HubPress/hubpress.io
+startertemplaterepo: https://github.com/HubPress/hubpress.io
 twitter: HubPressIO
 ---
 

--- a/src/site/generators/hugo.md
+++ b/src/site/generators/hugo.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Go
 description: A Fast and Flexible Static Site Generator.
-startertemplaterepo: netlify/victor-hugo
+startertemplaterepo: https://github.com/netlify/victor-hugo
 twitter: GoHugoIO
 ---
 

--- a/src/site/generators/jekyll.md
+++ b/src/site/generators/jekyll.md
@@ -10,7 +10,7 @@ templates:
   - Liquid
 description: A simple, blog-aware, static site generator.
 twitter: jekyllrb
-startertemplaterepo: netlify-templates/jekyll-base
+startertemplaterepo: https://github.com/netlify-templates/jekyll-base
 ---
 
 Jekyll is a simple, blog-aware, static site generator perfect for personal, project, or organization sites. Think of it like a file-based CMS, without all the complexity. Jekyll takes your content, renders Markdown and Liquid templates, and spits out a complete, static website ready to be served by Apache, Nginx or another web server. Jekyll is the engine behind [GitHub Pages](http://pages.github.com), which you can use to host sites right from your GitHub repositories.

--- a/src/site/generators/jungle.md
+++ b/src/site/generators/jungle.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Svelte
 description: JungleJS is a new static site generator that uses Svelte and GraphQL.
-startertemplaterepo: junglejs/template
+startertemplaterepo: https://github.com/junglejs/template
 twitter: jungle_js
 ---
 

--- a/src/site/generators/keystone.md
+++ b/src/site/generators/keystone.md
@@ -8,7 +8,7 @@ license:
   - ISC
 templates:
   - Custom
-startertemplaterepo: CTNicholas/keystone-ssg-example
+startertemplaterepo: https://github.com/CTNicholas/keystone-ssg-example
 description: Zero config static-site generator & dev server. Templates, partials, routing, Babel, SCSS/SASS, Markdown, bundling, minifying, dynamic linking, search indexing.
 ---
 

--- a/src/site/generators/kotsu.md
+++ b/src/site/generators/kotsu.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Nunjucks
 description: An extremely simple, pluggable static site generator.
-startertemplaterepo: LotusTM/Kotsu
+startertemplaterepo: https://github.com/LotusTM/Kotsu
 ---
 
 Static site generator and opinionated advanced web starter kit. Silently powers both large and small commercial projects.

--- a/src/site/generators/markbind.md
+++ b/src/site/generators/markbind.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Custom
 description: Optimized for generating technical documentation and educational websites from Markdown text.
-startertemplaterepo: MarkBind/init-typical-netlify
+startertemplaterepo: https://github.com/MarkBind/init-typical-netlify
 ---
 
 MarkBind is a website generator that can generate a website from markdown documents. While there are other markdown-to-html website generators around, MarkBind can generate more dynamic websites, as opposed to one-size-fits-all static content. MarkBind is particularly suitable to create content-heavy websites e.g., eLearning websites, online instruction manuals, project documentation etc. that aim for self-directed consumption.

--- a/src/site/generators/metalsmith.md
+++ b/src/site/generators/metalsmith.md
@@ -10,7 +10,7 @@ templates:
   - Handlebars
   - Any JS
 description: An extremely simple, pluggable static site generator.
-startertemplaterepo: andreasvirkus/metalsmith-boilerplate
+startertemplaterepo: https://github.com/andreasvirkus/metalsmith-boilerplate
 ---
 
 An extremely simple, _pluggable_ static site generator.

--- a/src/site/generators/middleman.md
+++ b/src/site/generators/middleman.md
@@ -11,7 +11,7 @@ templates:
   - Tilt
   - Haml
 description: Hand-crafted, modern frontend development.
-startertemplaterepo: wallin/middleman-template
+startertemplaterepo: https://github.com/wallin/middleman-template
 twitter: middlemanapp
 ---
 

--- a/src/site/generators/mini-site-generator.md
+++ b/src/site/generators/mini-site-generator.md
@@ -9,7 +9,7 @@ license:
 templates:
   - JavaScript
 description: It's just javascript!
-startertemplaterepo: ijmccallum/msg-starter
+startertemplaterepo: https://github.com/ijmccallum/msg-starter
 ---
 
 MSG is used in the food industry as a flavor enhancer with an umami taste that intensifies the meaty, savory flavor of - jkjkjk! I kid. It's literally just JavaScript.

--- a/src/site/generators/mkdocs.md
+++ b/src/site/generators/mkdocs.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Jinja2
 description: Project documentation with Markdown.
-startertemplaterepo: netlify-templates/mkdocs-base
+startertemplaterepo: https://github.com/netlify-templates/mkdocs-base
 twitter: MkDocsProject
 ---
 

--- a/src/site/generators/mkws.md
+++ b/src/site/generators/mkws.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Bash
 description: Efficient Static Site Generator
-startertemplaterepo: mkws-1/netlify-blank
+startertemplaterepo: https://github.com/mkws-1/netlify-blank
 twitter: mkws_1
 ---
 

--- a/src/site/generators/nanogen.md
+++ b/src/site/generators/nanogen.md
@@ -9,7 +9,7 @@ license:
 templates:
   - EJS
 description: A minimalist static site generator in Node.js.
-startertemplaterepo: doug2k1/nanogen-template
+startertemplaterepo: https://github.com/doug2k1/nanogen-template
 ---
 
 Minimalist static site generator written in Node.js.

--- a/src/site/generators/next.md
+++ b/src/site/generators/next.md
@@ -8,7 +8,7 @@ license:
   - MIT
 templates:
   - React
-startertemplaterepo: netlify-templates/next-starter-jamstack
+startertemplaterepo: https://github.com/netlify-templates/next-starter-jamstack
 description: A framework for statically-exported React apps (supports server side rendering)
 ---
 

--- a/src/site/generators/nift.md
+++ b/src/site/generators/nift.md
@@ -10,7 +10,7 @@ templates:
   - Custom
 description: A cross-platform open source git-like and LaTeX-like site manager.
 twitter: nifty_site_man
-startertemplaterepo: nsm-templates/basic-site
+startertemplaterepo: https://github.com/nsm-templates/basic-site
 ---
 
 Nift, short for nifty site manager, is a cross-platform open source git-like and LaTeX-like site manager. You should be able to create any site you want (both static and non-static/dynamic) using Nift, though will need some kind of web server such as Apache, NGinx, a LAMP stack, etc. to host non-static/dynamic sites, whereas static sites can easily be hosted with platforms like BitBucket, GitHub, GitLab and Netlify.

--- a/src/site/generators/nuxt.md
+++ b/src/site/generators/nuxt.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Vue
 description: A minimalistic framework for serverless Vue.js applications.
-startertemplaterepo: martinx3/nuxt-starter
+startertemplaterepo: https://github.com/martinx3/nuxt-starter
 twitter: nuxt_js
 ---
 

--- a/src/site/generators/orchid.md
+++ b/src/site/generators/orchid.md
@@ -10,7 +10,7 @@ license:
 templates:
   - Pebble
 description: A beautiful and truly unique documentation engine and static site generator.
-startertemplaterepo: JavaEden/OrchidStarter
+startertemplaterepo: https://github.com/JavaEden/OrchidStarter
 twitter: OrchidSSG
 ---
 

--- a/src/site/generators/orison.md
+++ b/src/site/generators/orison.md
@@ -9,7 +9,7 @@ license:
 templates:
   - lit-html
 description: Create pages, layouts, partials, and contextual data using lit-html
-startertemplaterepo: megazear7/orison-netlify-starter-kit
+startertemplaterepo: https://github.com/megazear7/orison-netlify-starter-kit
 ---
 
 OrisonJS is a static site generator built on top of lit-html.

--- a/src/site/generators/phenomic.md
+++ b/src/site/generators/phenomic.md
@@ -9,7 +9,7 @@ license:
 templates:
   - React
 description: A modern static website generator to create dynamic website using React components.
-startertemplaterepo: capriosa/phenomic-cms
+startertemplaterepo: https://github.com/capriosa/phenomic-cms
 twitter: Phenomic_app
 ---
 

--- a/src/site/generators/platframe.md
+++ b/src/site/generators/platframe.md
@@ -10,7 +10,7 @@ templates:
   - Pug
   - Jade
 description: A structured, scalable and modular platform for web and frontend development.
-startertemplaterepo: platframe/platframe
+startertemplaterepo: https://github.com/platframe/platframe
 twitter: platframe
 ---
 

--- a/src/site/generators/qgoda.md
+++ b/src/site/generators/qgoda.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Template Toolkit 2
 description: A sophisticated, blog-aware static site generator with unprecedented multi-language features
-startertemplaterepo: gflohr/qgoda-multilang
+startertemplaterepo: https://github.com/gflohr/qgoda-multilang
 ---
 
 Qgoda is a sophisticated static site generator following the Do-The-Right-Thing&trade; philosophy. Micro-sites require zero-configuration, a blog is easily started with one of the sample themes, but you can always grow with your needs and create arbitrarily complex sites with Qgoda.

--- a/src/site/generators/react-static.md
+++ b/src/site/generators/react-static.md
@@ -9,7 +9,7 @@ license:
 templates:
   - React
 description: A progressive static-site framework for React.
-startertemplaterepo: tannerlinsley/react-static-starter
+startertemplaterepo: https://github.com/tannerlinsley/react-static-starter
 ---
 
 React-Static is a fast, lightweight, and powerful toolkit for building static-progressive React applications and websites. Inspired by create-react-app, it's been carefully designed to meet the highest standards of **SEO, site performance, and user/developer experience**. [**Read the introduction article on Medium**](https://medium.com/@tannerlinsley/%EF%B8%8F-introducing-react-static-a-progressive-static-site-framework-for-react-3470d2a51ebc)

--- a/src/site/generators/routify.md
+++ b/src/site/generators/routify.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Svelte
 description: Routes for Svelte, automated by your file structure.
-startertemplaterepo: roxiness/routify-starter
+startertemplaterepo: https://github.com/roxiness/routify-starter
 twitter: routifyjs
 ---
 

--- a/src/site/generators/sapper.md
+++ b/src/site/generators/sapper.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Svelte
 description: Sapper is a framework for building high-performance universal web apps.
-startertemplaterepo: sveltejs/sapper-template
+startertemplaterepo: https://github.com/sveltejs/sapper-template
 ---
 
 Sapper is a framework for building high-performance universal web apps. [Read the guide](https://sapper.svelte.dev/docs) or the [introductory blog post](https://svelte.dev/blog/sapper-towards-the-ideal-web-app-framework) to learn more.

--- a/src/site/generators/sasige.md
+++ b/src/site/generators/sasige.md
@@ -9,7 +9,7 @@ license:
 templates:
   - PHP
 description: One word, TextToWebsite. Sasige will generate static html files and a combination of these is your website.
-startertemplaterepo: brainfoolong/sasige-starter
+startertemplaterepo: https://github.com/brainfoolong/sasige-starter
 ---
 
 In one word: `TextToWebsite`. Sasige will generate static html files and a combination of these is your website. We give you the tools to make a blog alike website, to make a documentation website, to make what every you can imagine. This documentation website you currently read is, for sure, generated with Sasige.

--- a/src/site/generators/sergey.md
+++ b/src/site/generators/sergey.md
@@ -9,7 +9,7 @@ license:
 templates:
   - HTML
 description: The little static site generator
-startertemplaterepo: trys/sergey-netlify
+startertemplaterepo: https://github.com/trys/sergey-netlify
 ---
 
 Sergey is a tiny lil’ static site generator. It’s a progressive tool designed to sit atop your already brilliant HTML. In essence, Sergey is HTML + partials with slots (named and default) & opt-in Markdown thrown in for good measure.

--- a/src/site/generators/skua.md
+++ b/src/site/generators/skua.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Jinja2
 description: A configurable Pythonic static site generator.
-startertemplaterepo: teymour-aldridge/skua-starter-project
+startertemplaterepo: https://github.com/teymour-aldridge/skua-starter-project
 ---
 
 Skua is a static site generator written in Python. Unlike many static site generators Skua doesn't offer a command-line interface – instead Skua projects are written using regular Python code which allows users to more easily customise their sites.

--- a/src/site/generators/slate.md
+++ b/src/site/generators/slate.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Markdown
 description: Beautiful static documentation for your API
-startertemplaterepo: slatedocs/slate
+startertemplaterepo: https://github.com/slatedocs/slate
 ---
 
 **Slate** helps you create beautiful, intelligent, responsive API documentation.

--- a/src/site/generators/soupault.md
+++ b/src/site/generators/soupault.md
@@ -10,7 +10,7 @@ templates:
   - HTML
   - Jingoo
 description: Website generator based on HTML rewriting instead of template processing. Single binary, extensible with Lua plugins.
-startertemplaterepo: dmbaturin/soupault-sample-blog
+startertemplaterepo: https://github.com/dmbaturin/soupault-sample-blog
 ---
 
 ## Based on element tree rewriting

--- a/src/site/generators/starter-project.md
+++ b/src/site/generators/starter-project.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Pug
 description: Starter Package is a package with the latest best practices for your HTML (pug), CSS (Sass), JavaScript (es6), graphic, font, and favicon files.
-startertemplaterepo: maliMirkec/starter-project
+startertemplaterepo: https://github.com/maliMirkec/starter-project
 twitter: malimirkeccita
 ---
 

--- a/src/site/generators/stasis-generator.md
+++ b/src/site/generators/stasis-generator.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Handlebars
 description: A static site generator that is simple and easy to use.
-startertemplaterepo: Gioni06/stasis-basic-example
+startertemplaterepo: https://github.com/Gioni06/stasis-basic-example
 ---
 
 Stasis is a simple and easy to use static site generator. It aims to provide production ready tools to create static website projects.

--- a/src/site/generators/statamic.md
+++ b/src/site/generators/statamic.md
@@ -13,7 +13,7 @@ templates:
   - Blade
   - Twig
   - Markdown
-startertemplaterepo: statamic/starter-kit-starters-creek
+startertemplaterepo: https://github.com/statamic/starter-kit-starters-creek
 description: A Laravel-powered, flat-first CMS that can run headless, as a full PHP stack, or generate and deploy static sites.
 ---
 

--- a/src/site/generators/static-site-express.md
+++ b/src/site/generators/static-site-express.md
@@ -9,7 +9,7 @@ license:
 templates:
   - EJS
 description: A simple Node.js based static site generator that uses EJS and Markdown.
-startertemplaterepo: SalsaBoy990/static-site-express
+startertemplaterepo: https://github.com/SalsaBoy990/static-site-express
 ---
 
 static-site-express is a simple Node.js based static site generator that uses EJS and Markdown. I created a complete [website/blog](https://static-site-express.netlify.com/) that you can easily and quickly customise, and publish it on Netlify.

--- a/src/site/generators/systatic.md
+++ b/src/site/generators/systatic.md
@@ -9,7 +9,7 @@ license:
 templates:
   - PHP
 description: Simple, Modern and Flexible
-startertemplaterepo: damcclean/systatic-demo
+startertemplaterepo: https://github.com/damcclean/systatic-demo
 twitter: systaticssg
 ---
 

--- a/src/site/generators/tome.md
+++ b/src/site/generators/tome.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Twig
 description: A static site generator lovingly crafted with Drupal 8.
-startertemplaterepo: drupal-tome/netlify-template
+startertemplaterepo: https://github.com/drupal-tome/netlify-template
 ---
 
 Tome is a static site generator built in Drupal 8. If you're a fan of Drupal,

--- a/src/site/generators/tropical.md
+++ b/src/site/generators/tropical.md
@@ -9,7 +9,7 @@ license:
 templates:
   - React
 description: Use modern tools to build fast, mostly-just-HTML websites with islands of rich client-side behaviour.
-startertemplaterepo: bensmithett/tropical
+startertemplaterepo: https://github.com/bensmithett/tropical
 ---
 
 Tropical is a flexible, component-first static site generator that lets you use modern tools to build fast, mostly-just-HTML websites with islands of rich client-side behaviour.

--- a/src/site/generators/vitepress.md
+++ b/src/site/generators/vitepress.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Vue
 description: Vue-powered Static Site Generator based on vite
-startertemplaterepo: anishkny/vitepress-starter
+startertemplaterepo: https://github.com/anishkny/vitepress-starter
 twitter: vuejs
 ---
 

--- a/src/site/generators/vuepress.md
+++ b/src/site/generators/vuepress.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Vue
 description: Vue-powered Static Site Generator
-startertemplaterepo: capriosa/vuepress-deploy
+startertemplaterepo: https://github.com/capriosa/vuepress-deploy
 twitter: vuepress
 ---
 

--- a/src/site/generators/yellow.md
+++ b/src/site/generators/yellow.md
@@ -1,7 +1,7 @@
 ---
 title: Yellow
 repo: datenstrom/yellow
-startertemplaterepo: datenstrom/yellow
+startertemplaterepo: https://github.com/datenstrom/yellow
 homepage: https://datenstrom.se/yellow/
 twitter: datenstromse
 language:

--- a/src/site/headless-cms/cannerio.md
+++ b/src/site/headless-cms/cannerio.md
@@ -8,7 +8,7 @@ typeofcms: "API Driven"
 supportedgenerators:
   - All
 description: Universal Content Management System(CMS) framework using React & Apollo GraphQL. Support Prisma, GraphQL, Firebase and Restful API 
-startertemplaterepo: Canner/canner-demo
+startertemplaterepo: https://github.com/Canner/canner-demo
 images:
   - path: /img/cms/canner-1.png
   - path: /img/cms/canner-2.png

--- a/src/site/headless-cms/netlify-cms.md
+++ b/src/site/headless-cms/netlify-cms.md
@@ -8,7 +8,7 @@ typeofcms: "Git-based"
 supportedgenerators:
   - All
 description: A different kind of CMS. It's a single page app written in React. It's an npm package. It's a script running on a static page that lives in your repo. Built for static site generators.
-startertemplaterepo: netlify-templates/one-click-hugo-cms
+startertemplaterepo: https://github.com/netlify-templates/one-click-hugo-cms
 images:
   - path: /img/cms/netlify-cms1.png
   - path: /img/cms/netlify-cms2.png

--- a/src/site/headless-cms/takeshape.md
+++ b/src/site/headless-cms/takeshape.md
@@ -7,7 +7,7 @@ typeofcms: "API Driven"
 supportedgenerators:
   - All
 description: "TakeShape is a GraphQL API-first Content-as-a-Service platform with an integrated Static Content Generator."
-startertemplaterepo: takeshape/takeshape-demo
+startertemplaterepo: https://github.com/takeshape/takeshape-demo
 images:
   - path: /img/cms/takeshape-project-list.png
   - path: /img/cms/takeshape-dashboard.png


### PR DESCRIPTION
Fix https://github.com/jamstack/jamstack.org/issues/434

Since it can take either a GitHub or GitLab path, I figured the best way to do it is just using the full path URL.