### PR TITLE
Fix typo in page 'Learning Resources'

### DIFF
--- a/src/site/resources/contentful-graphql-and-paid-content.md
+++ b/src/site/resources/contentful-graphql-and-paid-content.md
@@ -3,7 +3,7 @@ title: Contentful, GraphQL, and Paid Content
 date: 2020-08-06T00:00:00.000Z
 description: >-
   Learn how to combine Contentful’s powerful GraphQL API with Stripe to create paid content for your Jamstack app with Stefan Judis and Jason Lengstorf
-link: 'hhttps://www.learnwithjason.dev/contentful-graphql-paid-content'
+link: 'https://www.learnwithjason.dev/contentful-graphql-paid-content'
 thumbnailurl: /img/videos/lwj-contentful-graphql-and-paid-content.jpg
 featured: true
 type:


### PR DESCRIPTION
`hhttps` should be `https`.