### PR TITLE
Update Eleventy to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@11ty/eleventy": "^0.11.0",
+    "@11ty/eleventy": "^0.11.1",
     "@11ty/eleventy-cache-assets": "^2.0.3",
     "@fullhuman/postcss-purgecss": "^1.3.0",
     "autoprefixer": "^9.7.6",
@@ -27,9 +27,9 @@
     "dotenv": "^8.2.0",
     "fast-glob": "^3.2.4",
     "gray-matter": "^4.0.2",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.14.0",
     "lodash": "^4.17.20",
-    "luxon": "^1.23.0",
+    "luxon": "^1.25.0",
     "markdown-it": "^11.0.1",
     "netlify-plugin-minify-html": "^0.2.2",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
Also packaged in some other minor updates too. This was the beginning of an attempt to fix the dependabot issues at #467 but I don’t think they’re relevant any more since we deleted our package-lock.json and yarn lock files from the repo. Either way we can cement it with this explicit version upgrade.

Fixes #467 