### PR TITLE
Add Log4brains to generators

### DIFF
--- a/src/site/generators/log4brains.md
+++ b/src/site/generators/log4brains.md
@@ -1,0 +1,43 @@
+---
+title: Log4brains
+repo: thomvaill/log4brains
+homepage: https://github.com/thomvaill/log4brains
+language:
+  - JavaScript
+license:
+  - Apache-2.0
+templates:
+  - Markdown
+description: Docs-as-code knowledge base to manage Architecture Decision Records (ADR) for your project and publish them automatically as a static website
+---
+
+Log4brains is a docs-as-code knowledge base for your development and infrastructure projects.
+It enables you to write and manage [Architecture Decision Records](https://adr.github.io/) (ADR) right from your IDE, and to publish them automatically as a static website.
+
+It performs Static Site Generation from markdown files thanks to [Next.js](https://jamstack.org/generators/next/).
+
+## Install
+
+From your project's root directory:
+
+```sh
+npx init-log4brains
+```
+
+## Local preview
+
+```sh
+npm run log4brains-preview
+```
+
+## Build and deploy
+
+```sh
+npm run log4brains-build
+```
+
+See [Log4brains documentation](https://thomvaill.github.io/log4brains/adr/) for more information.
+
+## Example
+
+[Log4brains' own architecture knowledge base](https://thomvaill.github.io/log4brains/adr/)


### PR DESCRIPTION
Repo: https://github.com/thomvaill/log4brains

> Log4brains is a docs-as-code knowledge base for your development and infrastructure projects. It enables you to write and manage Architecture Decision Records (ADR) right from your IDE, and to publish them automatically as a static website.

I released this new project a few days ago, and I hope you will find it interesting enough to add it to your awesome list!
I am also looking for beta testers and any feedback will be very welcome! 🙏

Thanks!