### PR TITLE
updating google search console verification tag

### DIFF
--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -26,7 +26,7 @@ ogimage: "/img/og/default-og-image.png"
     <meta property="twitter:title" content="{{ title }} | Jamstack">
     <meta property="twitter:description" content="{{ description }}">
     <meta property="twitter:image" content="{{ netlify.deployUrl }}{{ ogimage }}">
-    <meta name="google-site-verification" content="i5IheizQ6X_M4jNqb_b7vbJrT34i_gvEg8Gxkq9IY_w" />
+    <meta name="google-site-verification" content="WDIQ_1X8K7XIpPJ5G1Z8KnOqdSeYetPQB4EgoTLfIsc" />
   </head>
   <body class="bg-blue-900 text-blue-100 leading-relaxed antialiased">
     <svg width="0" height="0" aria-hidden="true" style="position: absolute;">


### PR DESCRIPTION
our google search console `jamstack.org` property needs re-verifying. 

including this new meta tag on production site will allow us to verify and manage domain in gsc.