### PR TITLE
adding initial google-site-verification tag back in

### DIFF
--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -26,6 +26,7 @@ ogimage: "/img/og/default-og-image.png"
     <meta property="twitter:title" content="{{ title }} | Jamstack">
     <meta property="twitter:description" content="{{ description }}">
     <meta property="twitter:image" content="{{ netlify.deployUrl }}{{ ogimage }}">
+    <meta name=google-site-verification content=i5IheizQ6X_M4jNqb_b7vbJrT34i_gvEg8Gxkq9IY_w>
     <meta name="google-site-verification" content="WDIQ_1X8K7XIpPJ5G1Z8KnOqdSeYetPQB4EgoTLfIsc" />
   </head>
   <body class="bg-blue-900 text-blue-100 leading-relaxed antialiased">

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -26,7 +26,7 @@ ogimage: "/img/og/default-og-image.png"
     <meta property="twitter:title" content="{{ title }} | Jamstack">
     <meta property="twitter:description" content="{{ description }}">
     <meta property="twitter:image" content="{{ netlify.deployUrl }}{{ ogimage }}">
-    <meta name=google-site-verification content=i5IheizQ6X_M4jNqb_b7vbJrT34i_gvEg8Gxkq9IY_w>
+    <meta name="google-site-verification" content="i5IheizQ6X_M4jNqb_b7vbJrT34i_gvEg8Gxkq9IY_w" />
     <meta name="google-site-verification" content="WDIQ_1X8K7XIpPJ5G1Z8KnOqdSeYetPQB4EgoTLfIsc" />
   </head>
   <body class="bg-blue-900 text-blue-100 leading-relaxed antialiased">


### PR DESCRIPTION
as per slack discussion, this initial tag removed (https://github.com/jamstack/jamstack.org/pull/499), may be tied to other google systems and services (zach recalls email alias setup needing this). adding this back in, just in case.