### PR TITLE
Pnh/community cleanup

### DIFF
--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -54,9 +54,7 @@ dd a:focus {
 p+p {
   @apply mt-4;
 }
-section.cards {
-  max-width: 66rem;
-}
+
 
 /*
   CTA links

--- a/src/site/_data/community.yaml
+++ b/src/site/_data/community.yaml
@@ -109,3 +109,7 @@
 - name: Amsterdam
   link: https://www.meetup.com/jamstack-amsterdam/
   feed: https://api.meetup.com/jamstack-amsterdam/events
+
+- name: Toronto
+  link: https://www.meetup.com/JAMstack-Toronto/
+  feed: https://api.meetup.com/JAMstack-Toronto/events

--- a/src/site/_data/community.yaml
+++ b/src/site/_data/community.yaml
@@ -1,168 +1,111 @@
-  - name: San Francisco
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-sf/
-    feed: https://api.meetup.com/Jamstack-sf/events
-  - name: Austin
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Austin/
-    feed: https://api.meetup.com/Jamstack-Austin/events
-  - name: Boston
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Boston/
-    feed: https://api.meetup.com/Jamstack-Boston/events
-  - name: Porto
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Porto/
-    feed: https://api.meetup.com/Jamstack-Porto/events
-  - name: New York city
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-nyc/
-    feed: https://api.meetup.com/Jamstack-nyc/events
-  - name: London
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-London/
-    feed: https://api.meetup.com/Jamstack-London/events
-  - name: Berlin
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack_berlin/
-    feed: https://api.meetup.com/Jamstack_berlin/events
-  - name: Wrocław
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Wroclaw/
-    feed: https://api.meetup.com/Jamstack-Wroclaw/events
-  - name: Portland
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Portland/
-    feed: https://api.meetup.com/Jamstack-Portland/events
-  - name: Hamburg
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Hamburg/
-    feed: https://api.meetup.com/Jamstack-Hamburg/events
-  - name: Bengaluru
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Bengaluru/
-    feed: https://api.meetup.com/Jamstack-Bengaluru/events
-  - name: Paris
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/fr-FR/Jamstack-paris/
-    feed: https://api.meetup.com/Jamstack-paris/events
-  - name: Seattle
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-seattle/
-    feed: https://api.meetup.com/Jamstack-seattle/events
-  - name: Tokyo
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://Jamstack-tokyo.connpass.com/
-  - name: Lisbon
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Lisbon/
-    feed: https://api.meetup.com/Jamstack-Lisbon/events
-  - name: Istanbul
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack/
-  - name: Oslo
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Oslo/
-    feed: https://api.meetup.com/Jamstack-Oslo/events
-  - name: Atlanta
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Atlanta/
-    feed: https://api.meetup.com/Jamstack-Atlanta/events
-  - name: Cincinnati
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Cincinnati/
-    feed: https://api.meetup.com/Jamstack-Cincinnati/events
-  - name: Phoenix
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack_PHX/
-    feed: https://api.meetup.com/Jamstack_PHX/events
-  - name: Minsk
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/ru-RU/Jamstack-Minsk/
-    feed: https://api.meetup.com/Jamstack-Minsk/events
-  - name: Chicago
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Chicago/
-    feed: https://api.meetup.com/Jamstack-Chicago/events
-  - name: Lagos
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Lagos/
-    feed: https://api.meetup.com/Jamstack-Lagos/events
-  - name: Denver
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Denver/
-    feed: https://api.meetup.com/Jamstack-Denver/events
-  - name: Israel
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-IL/
-    feed: https://api.meetup.com/Jamstack-IL/events
-  - name: Yemen
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.facebook.com/groups/JamstackYemenMeetups
-  - name: Florence
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack_Florence/
-    feed: https://api.meetup.com/Jamstack_Florence/events
-  - name: Detroit
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Detroit/
-    feed: https://api.meetup.com/Jamstack-Detroit/events
-  - name: Singapore
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Singapore/
-    feed: https://api.meetup.com/Jamstack-Singapore/events
-  - name: Abuja
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.meetup.com/Jamstack-Abuja/
-    feed: https://api.meetup.com/Jamstack-Abuja/events
-  - name: Philadelphia
-    themecolor: '#000'
-    btncopy: Join Now
-    link: http://www.meetup.com/Jamstack-Philly/
-    feed: http://api.meetup.com/Jamstack-Philly/events
-  - name: Ulaanbaatar
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://www.facebook.com/groups/JamstackUlaanbaatar/
-  - name: Warri
-    themecolor: '#000'
-    btncopy: Join Now
-    link: https://m.facebook.com/groups/473905470150140
-  - name: Mexico City
-    themecolor: "#000"
-    btncopy: Join Now
-    link: https://www.meetup.com/JAMstack-Mexico-City/
-  - name: Amsterdam
-    themecolor: "#000"
-    btncopy: Join Now
-    link: https://www.meetup.com/jamstack-amsterdam/
+- name: San Francisco
+  link: https://www.meetup.com/Jamstack-sf/
+  feed: https://api.meetup.com/Jamstack-sf/events
+
+- name: Austin
+  link: https://www.meetup.com/Jamstack-Austin/
+  feed: https://api.meetup.com/Jamstack-Austin/events
+
+- name: Boston
+  link: https://www.meetup.com/Jamstack-Boston/
+  feed: https://api.meetup.com/Jamstack-Boston/events
+
+- name: Porto
+  link: https://www.meetup.com/Jamstack-Porto/
+  feed: https://api.meetup.com/Jamstack-Porto/events
+
+- name: New York city
+  link: https://www.meetup.com/Jamstack-nyc/
+  feed: https://api.meetup.com/Jamstack-nyc/events
+
+- name: London
+  link: https://www.meetup.com/Jamstack-London/
+  feed: https://api.meetup.com/Jamstack-London/events
+
+- name: Berlin
+  link: https://www.meetup.com/Jamstack_berlin/
+  feed: https://api.meetup.com/Jamstack_berlin/events
+
+- name: Wrocław
+  link: https://www.meetup.com/Jamstack-Wroclaw/
+  feed: https://api.meetup.com/Jamstack-Wroclaw/events
+
+- name: Portland
+  link: https://www.meetup.com/Jamstack-Portland/
+  feed: https://api.meetup.com/Jamstack-Portland/events
+
+- name: Hamburg
+  link: https://www.meetup.com/Jamstack-Hamburg/
+  feed: https://api.meetup.com/Jamstack-Hamburg/events
+
+- name: Bengaluru
+  link: https://www.meetup.com/Jamstack-Bengaluru/
+  feed: https://api.meetup.com/Jamstack-Bengaluru/events
+
+- name: Paris
+  link: https://www.meetup.com/fr-FR/Jamstack-paris/
+  feed: https://api.meetup.com/Jamstack-paris/events
+
+- name: Seattle
+  link: https://www.meetup.com/Jamstack-seattle/
+  feed: https://api.meetup.com/Jamstack-seattle/events
+
+- name: Lisbon
+  link: https://www.meetup.com/Jamstack-Lisbon/
+  feed: https://api.meetup.com/Jamstack-Lisbon/events
+
+- name: Istanbul
+  link: https://www.meetup.com/Jamstack/
+  feed: https://api.meetup.com/Jamstack/events
+
+- name: Oslo
+  link: https://www.meetup.com/Jamstack-Oslo/
+  feed: https://api.meetup.com/Jamstack-Oslo/events
+
+- name: Atlanta
+  link: https://www.meetup.com/Jamstack-Atlanta/
+  feed: https://api.meetup.com/Jamstack-Atlanta/events
+
+- name: Cincinnati
+  link: https://www.meetup.com/Jamstack-Cincinnati/
+  feed: https://api.meetup.com/Jamstack-Cincinnati/events
+
+- name: Phoenix
+  link: https://www.meetup.com/Jamstack_PHX/
+  feed: https://api.meetup.com/Jamstack_PHX/events
+
+- name: Minsk
+  link: https://www.meetup.com/ru-RU/Jamstack-Minsk/
+  feed: https://api.meetup.com/Jamstack-Minsk/events
+
+- name: Chicago
+  link: https://www.meetup.com/Jamstack-Chicago/
+  feed: https://api.meetup.com/Jamstack-Chicago/events
+
+- name: Lagos
+  link: https://www.meetup.com/Jamstack-Lagos/
+  feed: https://api.meetup.com/Jamstack-Lagos/events
+
+- name: Denver
+  link: https://www.meetup.com/Jamstack-Denver/
+  feed: https://api.meetup.com/Jamstack-Denver/events
+
+- name: Florence
+  link: https://www.meetup.com/Jamstack_Florence/
+  feed: https://api.meetup.com/Jamstack_Florence/events
+
+- name: Detroit
+  link: https://www.meetup.com/Jamstack-Detroit/
+  feed: https://api.meetup.com/Jamstack-Detroit/events
+
+- name: Philadelphia
+  link: https://www.meetup.com/jamstack-phl
+  feed: https://api.meetup.com/jamstack-phl/events
+
+- name: Mexico City
+  link: https://www.meetup.com/JAMstack-Mexico-City/
+  feed: https://api.meetup.com/JAMstack-Mexico-City/events
+
+- name: Amsterdam
+  link: https://www.meetup.com/jamstack-amsterdam/
+  feed: https://api.meetup.com/jamstack-amsterdam/events


### PR DESCRIPTION
- removes inactive groups from the community list (closes #486)
- add the excellent toronto meetup group
- remove legacy data fields from the community yaml
- make community grid conform to layout width 