### PR TITLE
fresh invite link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@
   status = 302
 
 [[redirects]]
-  from = "/"
+  from = "/slack"
   to = "https://join.slack.com/t/jamstack/shared_invite/zt-kp3asm76-~0QDRYOeBjnd1Hk9tMTAtA"
   status = 302
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,8 +16,8 @@
   status = 302
 
 [[redirects]]
-  from = "/slack"
-  to = "https://join.slack.com/t/jamstack/shared_invite/zt-fpqaceec-SZuiLEa7YdLUXHAXrWPWgQ"
+  from = "/"
+  to = "https://join.slack.com/t/jamstack/shared_invite/zt-kp3asm76-~0QDRYOeBjnd1Hk9tMTAtA"
   status = 302
 
 [[redirects]]


### PR DESCRIPTION
The slack invite link expires every 30 days. Here's a fresh one.