### PR TITLE
Adds filters by country to User Groups on Community page

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^8.2.0",
     "fast-glob": "^3.2.4",
     "gray-matter": "^4.0.2",
+    "i18n-iso-countries": "^6.4.0",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.20",
     "luxon": "^1.25.0",
@@ -38,6 +39,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.1.10",
     "postcss-cli": "^8.3.0",
+    "placename": "^1.1.2",
     "postcss-import": "^13.0.0",
     "spdx-correct": "^3.1.1",
     "tailwindcss": "^2.0.1"

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -318,7 +318,8 @@ details[open] .summary-swap-open {
 .filter-typeofcms--hide,
 .filter-language--hide,
 .filter-template--hide,
-.filter-license--hide {
+.filter-license--hide,
+.filter-country--hide {
   display: none !important;
 }
 /* purgecss end ignore */

--- a/src/site/_data/community.yaml
+++ b/src/site/_data/community.yaml
@@ -14,7 +14,7 @@
   link: https://www.meetup.com/Jamstack-Porto/
   feed: https://api.meetup.com/Jamstack-Porto/events
 
-- name: New York city
+- name: New York City
   link: https://www.meetup.com/Jamstack-nyc/
   feed: https://api.meetup.com/Jamstack-nyc/events
 

--- a/src/site/_data/community.yaml
+++ b/src/site/_data/community.yaml
@@ -9,6 +9,7 @@
 - name: Boston
   link: https://www.meetup.com/Jamstack-Boston/
   feed: https://api.meetup.com/Jamstack-Boston/events
+  country: United States of America
 
 - name: Porto
   link: https://www.meetup.com/Jamstack-Porto/

--- a/src/site/_data/eleventyComputed.js
+++ b/src/site/_data/eleventyComputed.js
@@ -20,7 +20,7 @@ function getCountryName(countryCode) {
 }
 
 module.exports = {
-  communityWithCountries: async function(data) {
+  community: async function(data) {
     let community = data.community.filter(e => true);
     for(let meetup of community) {
       // sry for await in loop

--- a/src/site/_data/eleventyComputed.js
+++ b/src/site/_data/eleventyComputed.js
@@ -23,10 +23,15 @@ module.exports = {
   community: async function(data) {
     let community = data.community.filter(e => true);
     for(let meetup of community) {
+      // skip if populated in the YAML file
+      if(meetup.country) {
+        continue;
+      }
+
       // sry for await in loop
       let countryCode = await getCountryCode(meetup.name);
       if(countryCode) {
-        meetup.countryName = getCountryName(countryCode);
+        meetup.country = getCountryName(countryCode);
       }
     }
 

--- a/src/site/_data/eleventyComputed.js
+++ b/src/site/_data/eleventyComputed.js
@@ -1,0 +1,35 @@
+const placename = require("placename");
+const lookupCountryName = require("i18n-iso-countries");
+
+async function getCountryCode(searchTerm) {
+  return new Promise(resolve => {
+    placename(searchTerm, function (err, rows) {
+      if(rows.length) {
+        resolve(rows[0].country);
+      } else {
+        resolve();
+      }
+    })
+  });
+}
+
+function getCountryName(countryCode) {
+  if(countryCode) {
+    return lookupCountryName.getName(countryCode, "en", {select: "official"});
+  }
+}
+
+module.exports = {
+  communityWithCountries: async function(data) {
+    let community = data.community.filter(e => true);
+    for(let meetup of community) {
+      // sry for await in loop
+      let countryCode = await getCountryCode(meetup.name);
+      if(countryCode) {
+        meetup.countryName = getCountryName(countryCode);
+      }
+    }
+
+    return community;
+  }
+};

--- a/src/site/community.njk
+++ b/src/site/community.njk
@@ -80,7 +80,7 @@ layout: layouts/base.njk
         <span class="sr-only">Country</span>
         <select data-filter-bind="country" class="text-black py-1 px-2 rounded-default border border-white bg-white">
           <option selected value="">All Countries</option>
-          {%- for country in community | select("countryName") | flatten | unique | sort(false, false) %}
+          {%- for country in community | select("country") | flatten | unique | sort(false, false) %}
           <option value="{{ country | lower }}">{{ country }}</option>
           {%- endfor %}
         </select>
@@ -98,7 +98,7 @@ layout: layouts/base.njk
       {# chose a pseudorandom theme based on the city name #}
       {% set theme =  item.name.length % 4 %}
       <li
-      {%- if item.countryName %} data-filter-country="{{ item.countryName | lower }}"{% endif %}>
+      {%- if item.country %} data-filter-country="{{ item.country | lower }}"{% endif %}>
         {{ meetup.card( item.name, item.link, themes[theme] ) }}
       </li>
       {%- endfor %}

--- a/src/site/community.njk
+++ b/src/site/community.njk
@@ -80,7 +80,7 @@ layout: layouts/base.njk
         <span class="sr-only">Country</span>
         <select data-filter-bind="country" class="text-black py-1 px-2 rounded-default border border-white bg-white">
           <option selected value="">All Countries</option>
-          {%- for country in communityWithCountries | select("countryName") | flatten | unique | sort(false, false) %}
+          {%- for country in community | select("countryName") | flatten | unique | sort(false, false) %}
           <option value="{{ country | lower }}">{{ country }}</option>
           {%- endfor %}
         </select>
@@ -93,7 +93,7 @@ layout: layouts/base.njk
         "bg-gradient-card-seafoam hover:card-shadow-seafoam",
         "bg-gradient-card-gold hover:card-shadow-gold"]
       %}
-      {%- for item in communityWithCountries | sort(false, false, 'name') %}
+      {%- for item in community | sort(false, false, 'name') %}
 
       {# chose a pseudorandom theme based on the city name #}
       {% set theme =  item.name.length % 4 %}

--- a/src/site/community.njk
+++ b/src/site/community.njk
@@ -70,24 +70,40 @@ layout: layouts/base.njk
 
 <section class="cards">
   <h2 class="mb-12">Find a Local User Group</h2>
-  <ul class="grid grid-cols-2 lg:grid-cols-3 gap-8">
+  <filter-container>
+    <form class="pb-4">
+      <div class="pb-2">
+        <strong class="pr-4">Filter</strong>
+        <span data-filter-results></span>
+      </div>
+      <label class="inline-flex pr-4 pb-2">
+        <span class="sr-only">Country</span>
+        <select data-filter-bind="country" class="text-black py-1 px-2 rounded-default border border-white bg-white">
+          <option selected value="">All Countries</option>
+          {%- for country in communityWithCountries | select("countryName") | flatten | unique | sort(false, false) %}
+          <option value="{{ country | lower }}">{{ country }}</option>
+          {%- endfor %}
+        </select>
+      </label>
+    </form>
+    <ul class="grid grid-cols-2 lg:grid-cols-3 gap-8">
+      {% set themes = [
+        "bg-gradient-card-sunrise hover:card-shadow-sunrise",
+        "bg-gradient-card-blue hover:card-shadow-blue-seafoam",
+        "bg-gradient-card-seafoam hover:card-shadow-seafoam",
+        "bg-gradient-card-gold hover:card-shadow-gold"]
+      %}
+      {%- for item in communityWithCountries | sort(false, false, 'name') %}
 
-
-    {% set themes = [
-      "bg-gradient-card-sunrise hover:card-shadow-sunrise",
-      "bg-gradient-card-blue hover:card-shadow-blue-seafoam",
-      "bg-gradient-card-seafoam hover:card-shadow-seafoam",
-      "bg-gradient-card-gold hover:card-shadow-gold"]
-    %}
-    {%- for item in community | sort(false, false, 'name') %}
-
-    {# chose a pseudorandom theme based on the city name #}
-    {% set theme =  item.name.length % 4 %}
-    <li>
-      {{ meetup.card( item.name, item.link, themes[theme] ) }}
-    </li>
-    {%- endfor %}
-  </ul>
+      {# chose a pseudorandom theme based on the city name #}
+      {% set theme =  item.name.length % 4 %}
+      <li
+      {%- if item.countryName %} data-filter-country="{{ item.countryName | lower }}"{% endif %}>
+        {{ meetup.card( item.name, item.link, themes[theme] ) }}
+      </li>
+      {%- endfor %}
+    </ul>
+  </filter-container>
 </section>
 
 <section>


### PR DESCRIPTION
Augments `community` global data from the YAML file to add `country` using some npm packages and eleventyComputed. I’m kinda proud of this approach! You *can* add the full `country` name in the community.yaml file if you want but it’s not necessary. Might be a useful escape hatch later for super-obscure locations. Uses the `<filter-container>` web component.