### PR TITLE
Fix GrazeDocs language

### DIFF
--- a/src/site/generators/grazedocs.md
+++ b/src/site/generators/grazedocs.md
@@ -3,7 +3,7 @@ title: GrazeDocs
 repo: mikoskinen/GrazeDocs
 homepage: https://grazedocs.io/
 language:
-  - CSharp
+  - C#
 license:
   - MIT
 templates:


### PR DESCRIPTION
Changed GrazeDocs language, from CSharp to C#. So now it's listed with other C# written static site generators.