### PR TITLE
feat: add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ type:
 
 Before submitting a pull request, or if you are suggesting/contributing code or content changes, it is wise to preview your change in a local build. We've tried to make the process of running a local build as low as possible.
 
+## Contributor over time
+
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=jamstack/jamstack.org)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=jamstack/jamstack.org)
 
 ## Running a local build
 


### PR DESCRIPTION
Hi, community!

To better present how our community grows, we develop a tool to show contributors growing history on [https://github.com/api7/contributor-graph](https://github.com/api7/contributor-graph). Since we found it helpful, we think maybe if it could help some other community.

## WHAT IT IS

Basically, it just shows the contributors growth over time, just like the stargazers over time on the README. It would be the same with stars that we would update the graph each day, so the link would always present the real-time data. There is some other stuff to play around with if you would like to give it a try~

![image](https://user-images.githubusercontent.com/72343596/119220762-ad8c5400-bb1e-11eb-9ac1-cc1f73917d1b.png)

## HOW IT WORKS 

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each user.

Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻
