### PR TITLE
adding Yerevan as Armenia

### DIFF
--- a/src/site/_data/community.yaml
+++ b/src/site/_data/community.yaml
@@ -119,3 +119,7 @@
 - name: Nuremberg
   link: https://www.meetup.com/jamstack-nuremberg/
   feed: https://api.meetup.com/jamstack-nuremberg/events
+
+- name: Yerevan
+  link: https://www.meetup.com/jamstack-armenia/
+  feed: https://api.meetup.com/jamstack-armenia/events


### PR DESCRIPTION
Adds a link to the Yerevan meetup group which is currently labeled on meetup as Jamstack Armenia