### PR TITLE
Add GatherContent as headless CMS offering

### DIFF
--- a/src/site/headless-cms/gathercontent.md
+++ b/src/site/headless-cms/gathercontent.md
@@ -1,0 +1,42 @@
+---
+title: GatherContent
+homepage: https://www.gathercontent.com/
+twitter: gathercontent
+opensource: "No"
+typeofcms: "API Driven"
+supportedgenerators:
+- Gatsby
+- Next
+- Other
+description: GatherContent is a headless Content Operations Platform, helping thousands of organisations around the world to create quality content, in less time, and at scale.
+---
+GatherContent is a headless Content Operations Platform, helping thousands of organisations around the world to create quality content, in less time, and at scale. Our focus is on bridging the gap, and acting as the glue between development teams and content creators.
+
+## Getting started with GatherContent as a headless CMS
+
+Start a free trial at [GatherContent](https://gathercontent.com/start-trial) and explore our Jamstack example project, which integrate with Vercel and Netlify.
+
+You can visit our [headless CMS example](https://github.com/gathercontent/headless-cms-example), view our [Gatsby starter project](https://github.com/gathercontent/gatsby-starter-gathercontent) or view our [API documentation](https://docs.gathercontent.com) to get started with GatherContent
+
+## Content delivery, without the baggage
+Our integrations, API and headless capabilities give development teams absolute flexibility when it comes to publishing.
+
+## Real-time collaborative editing
+Create content collaboratively with tools you’re used to. Your team will feel right at home.
+
+## Structured templates and components
+Structure content to save time and ensure consistency. Guidelines and instructions keep your content, and team focused.
+
+## Customisable workflow
+
+Set content workflows to ensure your content gets seen by the right people, at the right time, every time.
+
+## A hub for content operations
+
+Thousands of pieces of content to sort through? No problem. Organise, search, and manage content tasks with ease.
+
+### "If you can send an email you can use GatherContent"
+_Dominic Billington, Head of Marketing and Digital Experience, York St John University_
+
+
+![gathercontent](https://assets-global.website-files.com/5c88fc885559811e86314a3b/6001e1a04bff67771f74a9d6_gc_homepage_spot-2.svg)


### PR DESCRIPTION
GatherContent is a content operations platform that supports Jamstack via its API offering. 