### PR TITLE
adding Barcelona to the community

### DIFF
--- a/src/site/_data/community.yaml
+++ b/src/site/_data/community.yaml
@@ -128,3 +128,7 @@
   link: https://www.meetup.com/jamstack-stuttgart/
   feed: https://api.meetup.com/jamstack-stuttgart/events
   
+- name: Barcelona
+  link: https://www.meetup.com/jamstack-barcelona/
+  feed: https://api.meetup.com/jamstack-barcelona/events
+  


### PR DESCRIPTION
To close #638 and welcome the Barcelona meetup to the community.

Barcelona should now be visible on the `/community` page, and their future events should begin appearing in the touts of upcoming events.