### PR TITLE
Replace live-server with fork, dead-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:css": "postcss src/css/tailwind.css -o dist/css/styles.css",
     "watch:html": "ELEVENTY_ENV=dev eleventy --watch --quiet",
     "watch:css": "postcss src/css/tailwind.css -o dist/css/styles.css --watch",
-    "serve": "npx live-server dist --quiet --port=8090",
+    "serve": "npx dead-server dist --quiet --port=8090",
     "start": "npm-run-all --parallel watch:html watch:css serve",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
colors, a dependency of live-server, was bricked by the developer, breaking live-server. https://github.com/tapio/live-server/issues/387 live-server appears to be abandoned, so a user forked it as dead-server. https://github.com/tapio/live-server/issues/387#issuecomment-1008334750