### PR TITLE
Let the user decide where to open links

### DIFF
--- a/src/site/_includes/components/cards-meetup.njk
+++ b/src/site/_includes/components/cards-meetup.njk
@@ -1,6 +1,6 @@
 {% macro card(name, url, theme ) %}
 
-<a href="{{ url }}" target="_BLANK" rel="noopener" class="{{ theme }} bg-gradient-to-r block mb-4 border-gray-400 border rounded-xl rounded-tr-none text-center">
+<a href="{{ url }}" rel="noopener" class="{{ theme }} bg-gradient-to-r block mb-4 border-gray-400 border rounded-xl rounded-tr-none text-center">
   <div class="bg-gray-100 mt-3 py-8 rounded-xl-embed rounded-t-none card-shadow">
     <svg role="img" aria-label="Jamstack Group" aria-hidden="true" focusable="false" width="20" height="20" class="inline"><use xlink:href="#gem-jamstack" ></use></svg>
     <span class="font-bold ml-1">{{ name }} &rarr;</span>

--- a/src/site/_includes/components/example-thumbnail.njk
+++ b/src/site/_includes/components/example-thumbnail.njk
@@ -1,7 +1,7 @@
-<a href="{{ item.link }}" target="_BLANK" rel="noopener" class="mb-4 border-solid border-2 rounded bg-gray-600 block">
+<a href="{{ item.link }}" rel="noopener" class="mb-4 border-solid border-2 rounded bg-gray-600 block">
   <img src="{{ item.thumbnailurl }}" loading="lazy" alt="Screenshot of {{ item.title}}" class="border-t-2">
 </a>
-<h3><a href="{{ item.link }}" target="_BLANK" rel="noopener">{{ item.title }} →</a></h3>
+<h3><a href="{{ item.link }}" rel="noopener">{{ item.title }} →</a></h3>
 {% if item.date %}
 <time value="{{ item.date | formatDate('y-MM-dd') }}" class="text-gray-400 text-xs">{{ item.date | formatDate }} </time>
 {% endif %}

--- a/src/site/_includes/components/resource-link.njk
+++ b/src/site/_includes/components/resource-link.njk
@@ -1,5 +1,5 @@
 <li class="mt-6">
-  <h4 class="text-lg font-bold"><a href="{{ item.data.link }}" rel="noopener" target="_BLANK">{{ item.data.title }}</a></h4>
+  <h4 class="text-lg font-bold"><a href="{{ item.data.link }}" rel="noopener">{{ item.data.title }}</a></h4>
   <time value="{{ item.data.date | formatDate('y-MM-dd') }}" class="text-gray-400 text-xs">{{ item.data.date | formatDate }}</time>
   <p class="text-gray-600 text-xs">{{ item.data.link | domain }}</p>
 </li>

--- a/src/site/_includes/components/thumbnail-link.njk
+++ b/src/site/_includes/components/thumbnail-link.njk
@@ -1,4 +1,4 @@
-<a href="{{ item.data.link }}" target="_BLANK" rel="noopener" class="mb-4 border-solid border-2 rounded block text-gray-300 hover:text-red-500">
+<a href="{{ item.data.link }}" rel="noopener" class="mb-4 border-solid border-2 rounded block text-gray-300 hover:text-red-500">
   {% if item.data.thumbnailurl %}
   <img src="{{ item.data.thumbnailurl }}" loading="lazy" alt="{{ item.data.title }}">
   {% else %}
@@ -9,7 +9,7 @@
   {% endif %}
 </a>
 <h3>
-  <a href="{{ item.data.link }}" target="_BLANK" rel="noopener">{{ item.data.title }} →</a>
+  <a href="{{ item.data.link }}" rel="noopener">{{ item.data.title }} →</a>
 </h3>
 {% if item.data.date %}
 <time value="{{ item.data.date | formatDate('y-MM-dd') }}" class="text-gray-400 text-xs">{{ item.data.date | formatDate }} </time>

--- a/src/site/_includes/components/zinger-cta.njk
+++ b/src/site/_includes/components/zinger-cta.njk
@@ -1,6 +1,6 @@
 
 {% macro cta(text, url, theme, icon ) %}
-  <a href="{{ url }}" target="_BLANK" rel="noopener" class="block mb-4 md:inline-block {{ theme }} bg-gradient-to-r border-none p-6 rounded-xl rounded-tr-none text-center">
+  <a href="{{ url }}" rel="noopener" class="block mb-4 md:inline-block {{ theme }} bg-gradient-to-r border-none p-6 rounded-xl rounded-tr-none text-center">
     {% if icon %}<svg role="img" aria-label="{{ text }}" aria-hidden="true" focusable="false" width="40" height="40" class="mx-auto"><use xlink:href="{{ icon }}"></use></svg>{% endif %}
     <p class="font-bold text-lg {% if icon %}mt-2{% endif %}">
       {{ text }}

--- a/src/site/_includes/header.njk
+++ b/src/site/_includes/header.njk
@@ -50,13 +50,13 @@
       <div>
         <div class="text-center text-sm mb-4 text-gray-300">Connect with us</div>
         <div class="grid grid-cols-3 divide-x divide-gray-700 text-gray-300">
-          <a href="https://discord.gg/jamstack" target="_BLANK" rel="noopener" class="flex items-center justify-center p-4 hover:text-pink-500">
+          <a href="https://discord.gg/jamstack" rel="noopener" class="flex items-center justify-center p-4 hover:text-pink-500">
             <svg role="img" aria-label="Discord" focusable="false" width="36" height="36" class="fill-current"><use xlink:href="#logo-discord"></use></svg>
           </a>
-          <a href="https://twitter.com/jamstackconf" target="_BLANK" rel="noopener"  class="flex items-center justify-center p-4 hover:text-pink-500">
+          <a href="https://twitter.com/jamstackconf" rel="noopener"  class="flex items-center justify-center p-4 hover:text-pink-500">
             <svg role="img" aria-label="Twitter" focusable="false" width="34" height="28" class="fill-current"><use xlink:href="#logo-twitter"></use></svg>
           </a>
-          <a href="https://github.com/jamstack/jamstack.org" target="_BLANK" rel="noopener"  class="flex items-center justify-center p-4 hover:text-pink-500">
+          <a href="https://github.com/jamstack/jamstack.org" rel="noopener"  class="flex items-center justify-center p-4 hover:text-pink-500">
             <svg role="img" aria-label="GitHub" focusable="false" width="36" height="36" class="fill-current"><use xlink:href="#logo-github"></use></svg>
           </a>
         </div>

--- a/src/site/_includes/layouts/tool.njk
+++ b/src/site/_includes/layouts/tool.njk
@@ -35,21 +35,21 @@ layout: layouts/base.njk
     <dt class="sr-only">Home page</dt>
     <dd class="inline-block mr-6 whitespace-nowrap">
       <svg role="img" aria-hidden="true" focusable="false" width="20" height="20" class="fill-current inline-block mr-1"><use xlink:href="#icon-home"/></svg>
-      <a href="{{ homepage }}" target="_blank" rel="noopener">{{ homepage }}</a>
+      <a href="{{ homepage }}" rel="noopener">{{ homepage }}</a>
     </dd>
     {%- endif %}
     {%- if repo %}
     <dt class="sr-only">Repository</dt>
     <dd class="inline-block mr-6 whitespace-nowrap">
       <svg role="img" aria-hidden="true" focusable="false" width="20" height="20" class="fill-current inline-block mr-1"><use xlink:href="#icon-github"/></svg>
-      <a href="{% if not repohost or repohost == "github" %}https://github.com/{% endif %}{% if repohost == "gitlab" %}https://gitlab.com/{% endif %}{{ repo }}" target="_blank" rel="noopener">{{ repo }}</a>
+      <a href="{% if not repohost or repohost == "github" %}https://github.com/{% endif %}{% if repohost == "gitlab" %}https://gitlab.com/{% endif %}{{ repo }}" rel="noopener">{{ repo }}</a>
     </dd>
     {%- endif %}
     {%- if twitter %}
     <dt class="sr-only">Twitter</dt>
     <dd class="inline-block mr-6 whitespace-nowrap">
       <svg role="img" aria-hidden="true" focusable="false" width="20" height="20" class="fill-current inline-block mr-1"><use xlink:href="#icon-twitter"/></svg>
-      <a href="https://twitter.com/{{ twitter }}/" target="_blank" rel="noopener">@{{ twitter }}</a>
+      <a href="https://twitter.com/{{ twitter }}/" rel="noopener">@{{ twitter }}</a>
     </dd>
     {%- endif %}
   </dl>
@@ -86,8 +86,8 @@ layout: layouts/base.njk
     {% endfor %}
     {{ content | safe }}
   </div>
-  
-  
+
+
   {% if startertemplaterepo %}
   <a href="https://app.netlify.com/start/deploy?repository={{ startertemplaterepo }}" class="inline-block my-8 px-4 py-3 text-gray-700 bg-white rounded-lg text-center md:text-lg whitespace-nowrap border-t">
     <svg role="img" aria-hidden="true" focusable="false" width="30" height="30" viewBox="0 0 40 40" class="inline-block mr-1" fill="#36b0bb"><use xlink:href="#logo-netlify-gem"/></svg>

--- a/src/site/generators.njk
+++ b/src/site/generators.njk
@@ -76,7 +76,6 @@ layout: layouts/base.njk
 <section class="mt-12">
   <h2 class="text-white font-semi-bold text-3xl">Contribute</h2>
   <p>
-    Should your site be featured here in this gallery? Let us know about it by <a href="{{ pkg.repository.url }}" target="_BLANK" rel="noopener">opening a pull request</a>.
+    Should your site be featured here in this gallery? Let us know about it by <a href="{{ pkg.repository.url }}" rel="noopener">opening a pull request</a>.
   </p>
 </section>
-

--- a/src/site/headless-cms.njk
+++ b/src/site/headless-cms.njk
@@ -67,7 +67,6 @@ layout: layouts/base.njk
 <section class="mt-12">
   <h2 class="text-white font-semi-bold text-3xl">Contribute</h2>
   <p>
-    Should your site be featured here in this gallery? Let us know about it by <a href="{{ pkg.repository.url }}" target="_BLANK" rel="noopener">opening a pull request</a>.
+    Should your site be featured here in this gallery? Let us know about it by <a href="{{ pkg.repository.url }}" rel="noopener">opening a pull request</a>.
   </p>
 </section>
-

--- a/src/site/resources/articles.njk
+++ b/src/site/resources/articles.njk
@@ -47,6 +47,6 @@ layout: layouts/base.njk
   <h2 class="heading">Contribute</h2>
   <p>
     If you know of a article or a resource which could help people understand how to get the best out of the Jamstack,
-    you can contribute it to this list by <a href="{{ pkg.repository.url }}" target="_BLANK" rel="noopener">opening a pull request</a>.
+    you can contribute it to this list by <a href="{{ pkg.repository.url }}" rel="noopener">opening a pull request</a>.
   </p>
 </section>

--- a/src/site/resources/videos.njk
+++ b/src/site/resources/videos.njk
@@ -46,6 +46,6 @@ layout: layouts/base.njk
   <h2>Contribute</h2>
   <p>
     If you know of a presentation or a video which could help people understand how to get the best out of the Jamstack,
-    you can contribute it to this list by <a href="{{ pkg.repository.url }}" target="_BLANK" rel="noopener">opening a pull request</a>.
+    you can contribute it to this list by <a href="{{ pkg.repository.url }}" rel="noopener">opening a pull request</a>.
   </p>
 </section>


### PR DESCRIPTION
This pull request commits one changeset, removing all `target="_blank"`s from the templates. 
*Why?* Because there are a dozen ways to open a regular link in a new tab if the user wants to. But where is not a single reliable way to open links with `target="_blank"` in the current tab. So one should just let the user decide where the links should be opened, by either clicking on them normally or in a new tab by Cmd+click, context menu etc.