### PR TITLE
Update Next.js template repo

### DIFF
--- a/src/site/generators/next.md
+++ b/src/site/generators/next.md
@@ -8,7 +8,7 @@ license:
   - MIT
 templates:
   - React
-startertemplaterepo: https://github.com/cassidoo/next-netlify-starter
+startertemplaterepo: https://github.com/netlify-templates/next-netlify-starter
 description: A framework for statically-exported React apps (supports server side rendering)
 ---
 


### PR DESCRIPTION
## Summary

The previous repository pointing to that isn't being maintained anymore. Visually there are no changes to either the website or the repository link. We just want to be sure that the project can still be deployed successfully for folks.

Repository link: https://github.com/netlify-templates/next-netlify-starter
Demo link: https://next-starter.netlify.app