### PR TITLE
Update repo slug

### DIFF
--- a/src/site/generators/astro.md
+++ b/src/site/generators/astro.md
@@ -1,6 +1,6 @@
 ---
 title: Astro
-repo: snowpackjs/astro
+repo: withastro/astro
 homepage: https://astro.build
 language:
   - JavaScript


### PR DESCRIPTION
update displayname to the actual repo slug, however the old one still works as it redirects to the new one