### PR TITLE
Update payload-cms.md

### DIFF
--- a/src/site/headless-cms/payload-cms.md
+++ b/src/site/headless-cms/payload-cms.md
@@ -3,7 +3,7 @@ title: Payload CMS
 repo: payloadcms/payload
 homepage: https://payloadcms.com
 twitter: PayloadCMS
-opensource: "No"
+opensource: "Yes"
 typeofcms: "API Driven"
 supportedgenerators:
   - All


### PR DESCRIPTION
Payload CMS is now open source. 
Opensource changes to "Yes" in payload-cms.md