### PR TITLE
Fix typo in survey/workflows.njk

### DIFF
--- a/src/site/_includes/survey/workflows.njk
+++ b/src/site/_includes/survey/workflows.njk
@@ -26,7 +26,7 @@
     <tbody>
       <tr><td>Desktop browsers</td><td>84%</td><td>14%</td></tr>
       <tr><td>Phones</td><td>71%</td><td>24%</td></tr>
-      <tr><td>Tables</td><td>41%</td><td>50%</td></tr>
+      <tr><td>Tablets</td><td>41%</td><td>50%</td></tr>
       <tr><td>Watches / IoT</td><td>7%</td><td>18%</td></tr>
     </tbody>
   </table>


### PR DESCRIPTION
In the device section, 'tablets' was typo'd as 'tables'