### PR TITLE
Add cta to Jamstack Conf callout

### DIFF
--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -19,15 +19,20 @@ layout: layouts/base.njk
 </section>
 
 <section class="mb-10">
-  <a href="https://jamstackconf.com" class="border-2 border-white block rounded-xl shadow-lg text-center ">
-    <img src="/img/conf-2022-tout.png" alt="Jamstack Conf 2022" class="rounded-xl w-2/3 mx-auto my-8">
-    <p class="font-bold text-3xl my-0">
-      7-8 November 2022
+  <div class="border-2 border-white block rounded-xl shadow-lg text-center ">
+    <img src="/img/conf-2022-tout.png" alt="Jamstack Conf 2022" class="rounded-xl w-2/3 mx-auto my-6">
+    <p class="text-xl md:text-2xl mb-5 px-5">
+      <span class="font-bold">7-8 Nov 2022</span>
+      <span>·</span>
+      <span>San Francisco and online</span>
     </p>
-    <p class="font-bold text-lg md:text-xl mb-10 w-2/3 md:w-1/2 mx-auto">
+    <p class="text-lg md:text-xl mb-5 w-2/3 md:w-1/2 mx-auto">
       Join 20,000+ web developers for two days dedicated to building modern web projects.
     </p>
-  </a>
+    <p class="mb-5">
+      <a href="https://jamstackconf.com" class="cta">Attend Jamstack Conf</a>
+    </p>
+  </div>
 </section>
 
 


### PR DESCRIPTION
This PR:
- adds a CTA button to the Jamstack Conf callout on the landing page
- changes the containing anchor into a `<div>` so we don’t have nested links
- adds the location for the conf
- small style tweaks

<img width="897" alt="image" src="https://user-images.githubusercontent.com/871315/176965789-c6bcc41c-7301-4490-a6dd-a6e7e73758ab.png">
