### PR TITLE
Add jamstack conf site proxy redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,8 +12,18 @@
 
 [[redirects]]
   from = "/conference"
+  to = "/conf"
+  status = 301
+
+[[redirects]]
+  from = "/conf"
   to = "https://jamstackconf.com/"
-  status = 302
+  status = 200
+
+[[redirects]]
+  from = "/conf/*"
+  to = "https://jamstackconf.com/:splat"
+  status = 200
 
 [[redirects]]
   from = "/discord"
@@ -52,7 +62,7 @@
 
 [[redirects]]
   from = "/conf/cfp"
-  to = "https://docs.google.com/forms/d/e/1FAIpQLSeR5W4m9owqDBJEq2EuRUNXFTOeLCxFPUn0qbuCE15o4SWDFg/viewform"
+  to = "https://docs.google.com/forms/d/e/1FAIpQLSc-z50GyD7zXzr_JCn2M1NBFZ-h65kSdu7zn43V1u2qAKO3ew/viewform"
   status = 302
 
 [[redirects]]


### PR DESCRIPTION
This request adds 200 redirects so that we can view the `jamstackconf.com` site at `jamstack.org/conf`

Noting that the following redirect rules were added in a [PR](https://github.com/netlify/jamstack_conf/pull/291) on the jamstack_conf repo. Once published, this will need to be tested to ensure it won't cause an infinite loop – I have a hunch it may be the case but I'm unsure of how we can test this without merging

```
[[redirects]]
from = "/"
to = "https://jamstack.org/conf/"
status = 301
force = true

[[redirects]]
from = "/*"
to = "https://jamstack.org/conf/:splat"
status = 301
force = true
```