### PR TITLE
feat: remove conf redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -46,11 +46,6 @@
   status = 200
 
 [[redirects]]
-  from = "/conf/"
-  to = "https://jamstackconf.com/"
-  status = 302
-
-[[redirects]]
   from = "/conf/cfp"
   to = "https://docs.google.com/forms/d/e/1FAIpQLSeR5W4m9owqDBJEq2EuRUNXFTOeLCxFPUn0qbuCE15o4SWDFg/viewform"
   status = 302


### PR DESCRIPTION
Prep for the 2022 Jamstack Conf page. Removing this to avoid an infinite redirect loop.