### PR TITLE
fix typeofcms filter value

### DIFF
--- a/src/site/headless-cms/flycode.md
+++ b/src/site/headless-cms/flycode.md
@@ -4,7 +4,7 @@ homepage: https://flycode.com
 description: FlyCode helps product teams work like software engineers - to ship better products, faster with no-code 
 twitter: flycodeHQ
 opensource: "No"
-typeofcms: "Git based"
+typeofcms: "Git-based"
 supportedgenerators:
   - React
   - Angular


### PR DESCRIPTION
flycode.md is the only file which sets typeofcms to "Git based" instead of "Git-based".
This leads to the filter at https://jamstack.org/headless-cms/ to contain both versions even though they represent the same value