### PR TITLE
Fixed typeofcms for flycode

### DIFF
--- a/src/site/headless-cms/flycode.md
+++ b/src/site/headless-cms/flycode.md
@@ -4,7 +4,7 @@ homepage: https://flycode.com
 description: FlyCode helps product teams work like software engineers - to ship better products, faster with no-code 
 twitter: flycodeHQ
 opensource: "No"
-typeofcms: "Git based"
+typeofcms: "Git-based"
 supportedgenerators:
   - React
   - Angular


### PR DESCRIPTION
Flycode was put in a seperate category when filtering the cmstype on https://jamstack.org/headless-cms/, which should be fixed with this change!