### PR TITLE
Fix typo: ~Git based~ -> Git-based

### DIFF
--- a/src/site/headless-cms/flycode.md
+++ b/src/site/headless-cms/flycode.md
@@ -4,7 +4,7 @@ homepage: https://flycode.com
 description: FlyCode helps product teams work like software engineers - to ship better products, faster with no-code 
 twitter: flycodeHQ
 opensource: "No"
-typeofcms: "Git based"
+typeofcms: "Git-based"
 supportedgenerators:
   - React
   - Angular


### PR DESCRIPTION
If I look at https://jamstack.org/headless-cms/, then I see 4 categories.
- Any CMS Type
- API Driven
- Git-based
- Git based
![image](https://user-images.githubusercontent.com/77174844/193500975-6f9af294-175c-46f2-948a-5ee2a612f7d5.png)

There's only one instance of `Git based` headless CMS types so I think this change should just fix this.