### PR TITLE
Move up Jamstack Conf promo section

### DIFF
--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -8,6 +8,21 @@ layout: layouts/base.njk
 {% import "components/zinger-cta.njk" as zinger %}
 {% import "components/color-theme-selector.njk" as colorThemeToggle %}
 
+<section class="mb-10">
+  <div class="border-2 border-white bg-white dark:bg-blue-900 block rounded-xl shadow-lg text-center overflow-hidden">
+    <a href="/conf/">
+      <img src="/img/conf-2022-tout-new.png" alt="Jamstack Conf 2022, 7-8 November, San Francisco and online" width="1500" height="600"/>
+    </a>
+    <h2 class="mt-8">Join us at Jamstack Conf!</h2x>
+    <p class="mt-4 text-lg md:text-xl mb-5 w-2/3 md:w-1/2 mx-auto">
+      Join 20,000+ web developers for two days dedicated to building modern web projects.
+    </p>
+    <p class="mb-5">
+      <a href="/conf/" class="cta">Attend Jamstack Conf</a>
+    </p>
+  </div>
+</section>
+
 <section class="my-10 p-0">
   {{ ticker.icons() }}
   {{ ticker.main() }}
@@ -27,39 +42,24 @@ layout: layouts/base.njk
       </p>
       <p>
         It enables a composable architecture for the web where custom logic and 3rd party services are consumed through APIs.</p>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="mb-10">
-  <div class="border-2 border-white bg-white dark:bg-blue-900 block rounded-xl shadow-lg text-center overflow-hidden">
-    <a href="/conf/">
-      <img src="/img/conf-2022-tout-new.png" alt="Jamstack Conf 2022, 7-8 November, San Francisco and online" width="1500" height="600" />
-    </a>
-    <h2 class="mt-8">Join us at Jamstack Conf!</h2x>
-    <p class="mt-4 text-lg md:text-xl mb-5 w-2/3 md:w-1/2 mx-auto">
-      Join 20,000+ web developers for two days dedicated to building modern web projects.
-    </p>
-    <p class="mb-5">
-      <a href="/conf/" class="cta">Attend Jamstack Conf</a>
     </p>
   </div>
+</div>
 </section>
 
 {% include "components/join-the-movement.njk" %}
 
 <section class=" mb-16">
-  <div class="md:w-8/12 mx-auto">
-    <h2>The Roots of Jamstack</h2>
-    <p class="mt-6 mb-8">
-      <a href="https://www.netlify.com/authors/matt-biilmann/">Matt Biilmann</a> took the concept of Jamstack mainstream with his presentation at Smashing Conf 2016. Watch the quintessential introduction to the Jamstack.
+<div class="md:w-8/12 mx-auto">
+  <h2>The Roots of Jamstack</h2>
+  <p class="mt-6 mb-8">
+    <a href="https://www.netlify.com/authors/matt-biilmann/">Matt Biilmann</a> took the concept of Jamstack mainstream with his presentation at Smashing Conf 2016. Watch the quintessential introduction to the Jamstack.
     </p>
-    <div class="videowrapper mb-8">
-      <div data-lazyiframe src="https://player.vimeo.com/video/163522126?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen title="Mathias Biilmann Smashing Conf 2016 talk video: The New Front-End Stack">
-        <a href="https://vimeo.com/163522126">Watch <em>Mathias Biilmann Smashing Conf 2016 talk video: The New Front-End Stack</em> on Vimeo</a>
-      </div>
+  <div class="videowrapper mb-8">
+    <div data-lazyiframe src="https://player.vimeo.com/video/163522126?title=0&byline=0&portrait=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen title="Mathias Biilmann Smashing Conf 2016 talk video: The New Front-End Stack">
+      <a href="https://vimeo.com/163522126">Watch <em>Mathias Biilmann Smashing Conf 2016 talk video: The New Front-End Stack</em> on Vimeo</a>
     </div>
-    <a href="/resources/" class="cta">See more videos and resources</a>
   </div>
+  <a href="/resources/" class="cta">See more videos and resources</a>
+</div>
 </section>

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -15,7 +15,7 @@ layout: layouts/base.njk
     </a>
     <h2 class="mt-8">Join us at Jamstack Conf!</h2x>
     <p class="mt-4 text-lg md:text-xl mb-5 w-2/3 md:w-1/2 mx-auto">
-      Join 20,000+ web developers for two days dedicated to building modern web projects.
+      Join thousands of web developers for two days dedicated to building modern web projects.
     </p>
     <p class="mb-5">
       <a href="/conf/" class="cta">Attend Jamstack Conf</a>


### PR DESCRIPTION
Elevates the Jamstack Conference promo section to the top of the jamstack.org home page.