### PR TITLE
Update current tag on Headless CMS page

### DIFF
--- a/src/site/headless-cms.njk
+++ b/src/site/headless-cms.njk
@@ -8,7 +8,7 @@ layout: layouts/base.njk
 <section class="md:mt-20">
   <h1 class="text-center">Headless CMS</h1>
   <p class="text-center">
-    A List of Content Management Systems for Jamstack Sites
+    A list of <a href="https://www.netlify.com/blog/complete-guide-to-headless-cms/" target="_BLANK" rel="noopener">headless content management systems</a> for Jamstack sites
   </p>
 </section>
 

--- a/src/site/headless-cms.njk
+++ b/src/site/headless-cms.njk
@@ -8,7 +8,7 @@ layout: layouts/base.njk
 <section class="md:mt-20">
   <h1 class="text-center">Headless CMS</h1>
   <p class="text-center">
-    A list of <a href="https://www.netlify.com/blog/complete-guide-to-headless-cms/" target="_BLANK" rel="noopener">headless content management systems</a> for Jamstack sites
+    A list of <a href="https://www.netlify.com/blog/complete-guide-to-headless-cms/" target="_blank" rel="noopener">headless content management systems</a> for Jamstack sites
   </p>
 </section>
 


### PR DESCRIPTION
copy below the "Headless CMS" tag from its current state ("A List of Content Management Systems for Jamstack Sites") to "A list of headless content management systems for Jamstack sites." See ticket: https://github.com/netlify/marketing/issues/1911