### PR TITLE
Set canonical tag link

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 const lodashGet = require("lodash/get");
 const yaml = require("js-yaml");
+const { URL } = require("url");
 
 module.exports = function (eleventyConfig) {
   // Support yaml data files
@@ -37,6 +38,10 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPairedShortcode('markdown', (content) => {
     return md.render(content);
   });
+
+  eleventyConfig.addFilter('absoluteUrl', (url, base) => {
+    return (new URL(url, base)).toString() || url
+  })
 
 
   eleventyConfig.addFilter('convertFromEpoc', (time) => {

--- a/src/site/_data/meta.js
+++ b/src/site/_data/meta.js
@@ -1,0 +1,4 @@
+module.exports = {
+  lang: "en",
+  url: process.env.URL || "http://localhost:8080",
+};

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -5,7 +5,7 @@ ogimage: "/img/og/default-og-image.png"
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="{{ meta.lang }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,7 +18,7 @@ ogimage: "/img/og/default-og-image.png"
     <link rel="apple-touch-icon" sizes="180x180" href="/img/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/img/favicons/favicon-16x16.png">
-    <link rel="canonical" href="https://jamstack.org{{ page.url }}"/>
+    <link rel="canonical" href="{{ page.url | url | absoluteUrl(meta.url) }}"/>
 {%- for url in preconnect %}
     <link rel="preconnect" href="{{ url }}">
 {%- endfor %}

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -18,6 +18,7 @@ ogimage: "/img/og/default-og-image.png"
     <link rel="apple-touch-icon" sizes="180x180" href="/img/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/img/favicons/favicon-16x16.png">
+    <link rel="canonical" href="https://jamstack.org{{ page.url }}"/>
 {%- for url in preconnect %}
     <link rel="preconnect" href="{{ url }}">
 {%- endfor %}


### PR DESCRIPTION
- Adds new filter `absoluteUrl()`
- Sets `canonical` tag for jamstack.org sites