### PR TITLE
docsy: fix link

### DIFF
--- a/src/site/generators/docsy.md
+++ b/src/site/generators/docsy.md
@@ -1,6 +1,6 @@
 ---
 title: Docsy
-repo: https://github.com/google/docsy
+repo: google/docsy
 homepage: https://www.docsy.dev/
 language:
   - Go


### PR DESCRIPTION
else the generated link is `https://github.com/https://github.com/google/docsy` on https://jamstack.org/generators/docsy/