### PR TITLE
Create usecue-cms.md

### DIFF
--- a/src/site/headless-cms/usecue-cms.md
+++ b/src/site/headless-cms/usecue-cms.md
@@ -1,0 +1,36 @@
+---
+title: Usecue CMS
+homepage: https://cms.usecue.com
+opensource: "No"
+typeofcms: "Git-based"
+supportedgenerators:
+  - Hugo
+description: A Git-based CMS for the Hugo Static Site Generator. Manage your site's content with zero config.
+---
+## CloudCannon
+A Git-based CMS for the Hugo Static Site Generator. Manage your site's content with zero config.
+
+Turn your code into a CMS and create the perfect customer experience for your Hugo website. Made possible by our integrated hosting solution.
+
+### Features
+  - Zero config
+  - Multi user support
+  - Multilingual support
+  - Mobile first layout
+  - Instant previews
+  - Instant deploys
+  - Integrated analytics
+  - WYSIWYG editor
+  - Shortcode support
+  - Smart linking
+  - Reference counter
+  - Form handling
+  - Spam filter
+  - Hosting failover
+  - Instant pageloads
+  - Full Git support
+  - Commit messages
+  - Image resizing
+  - Image caching
+  - SVG support
+  - Daily rebuilds


### PR DESCRIPTION
Adds Usecue CMS (a SaaS CMS) to the Headless CMS list.