### PR TITLE
update hugo repo

### DIFF
--- a/src/site/generators/hugo.md
+++ b/src/site/generators/hugo.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Go
 description: A Fast and Flexible Static Site Generator.
-startertemplaterepo: https://github.com/netlify/victor-hugo
+startertemplaterepo: https://github.com/netlify-templates/hugo-quickstart
 twitter: GoHugoIO
 ---
 


### PR DESCRIPTION
This PR changes the source repo for Hugo's "deploy to Netlify" button. The previous repo is now archived, which led to `fetch failed` errors after selecting the button.