### PR TITLE
Garchi CMS added in site/headless-cms

### DIFF
--- a/src/site/headless-cms/garchicms.md
+++ b/src/site/headless-cms/garchicms.md
@@ -1,0 +1,53 @@
+---
+title: Garchi CMS
+homepage: https://garchi.co.uk
+typeofcms: "API Driven"
+opensource: "No"
+supportedgenerators:
+  - All
+description: Garchi CMS is a developer friendly headless CMS that bridges the gap between developers and content teams.
+
+---
+
+## Overview 
+
+Garchi CMS is a developer friendly headless CMS that bridges the gap between developers and content teams.
+
+It provides the flexibility and developer experience of a headless CMS while still empowering marketers to easily manage content across devices.
+
+## Key Features
+
+- Spaces to organize content
+- Assets management
+- Page builder with sections  
+- Build using ATOMIC design
+- Draft previews  
+- REST APIs
+- Data models with defined structure which could be customised as needed using key value pairs
+
+## Getting Started
+
+- Create an account at [garchi.co.uk](https://garchi.co.uk)
+- Generate an API key
+- Create components to match section templates 
+- Fetch content using the APIs
+- Populate components with content
+
+
+## What can you build with Garchi CMS?
+
+Garchi CMS is designed in a way that it could fit with any tech stack. To be honest, sky is the limit but to cite some few examples, using Garchi CMS you could build
+
+- Event booking platforms
+- E-commerce store
+- Image galleries
+- Movie platforms
+- E-learning platforms
+- CRM
+- Blog
+- Portfolio website
+
+## Resources
+
+- [Docs](https://garchi.co.uk/documentation).
+- [API Docs](https://garchi.co.uk/docs/v2)


### PR DESCRIPTION
Hi,

We have a headless CMS SaaS product named [Garchi CMS] (https://garchi.co.uk)

We would like to showcase it on jamstack.org/headless-cms site. 

In README.md it states to add a resource but I wasn't sure how to add it as a listing so I have added it in 

src/site/headless-cms