### PR TITLE
Add Modulo.js Generator Info Page

### DIFF
--- a/src/site/generators/modulojs.md
+++ b/src/site/generators/modulojs.md
@@ -1,0 +1,34 @@
+---
+title: Modulo.js
+repo: modulojs/modulo
+homepage: https://modulojs.org/
+language:
+  - JavaScript
+license:
+  - LGPL 3.0
+templates:
+  - Modulo (similar to Liquid or Jinja)
+description: An easy-to-use, zero-dependency Jamstack framework in 2000 lines
+startertemplaterepo: https://github.com/modulojs/modulo-jamstack-deploy
+---
+
+**The lightest, dependency-free way to start a Jamstack project:**
+
+```
+npm init modulo
+```
+
+Say goodbye to slow builds and heavy dependencies, `node_modules`, and build
+servers: Get work done without that!
+
+[Documentation on Modulo Jamstack is available here.](https://modulojs.org/tutorial/building-apps/part1.html)
+
+
+The Moduolo.js Jamstack template includes: Netlify / Decap CMS ready-to-go,
+most of the features you'd expect with React.js or Vue.js, including state,
+props, directives, templating, data binding and reactive forms, templating,
+global store and sub/pub, hydration, DOM reconciliation tools, and more, **all
+with zero dependencies** save for the 2000 line file. The integrated Markdown,
+Decap CMS, Netlify-safe SSR, and is already setup, with local or `unpkg`-based
+dependencies.
+


### PR DESCRIPTION
This pull request adds a markdown page describing the open source Modulo.js web component and templating library, with a link to the Netlify one click deploy. Thanks!