### PR TITLE
Add Mattrbld headless CMS

### DIFF
--- a/src/site/headless-cms/mattrbld.md
+++ b/src/site/headless-cms/mattrbld.md
@@ -1,0 +1,25 @@
+---
+title: Mattrbld
+homepage: https://mattrbld.com/
+opensource: "No"
+typeofcms: "Git-based"
+supportedgenerators:
+  - All
+description: A Git-based headless CMS built with modern technologies running right in your browser and installable to all your devices as a PWA
+---
+
+## What is Mattrbld
+
+Mattrbld is a headless content management system for teams and individuals who don’t want to be locked into a specific platform or framework. It offers a fast and flexible way to create, edit and manage content while giving developers complete control over the shape of the data, so they are free to use any frontend technologies they like.
+
+### Familiar, but better
+
+If you’ve used a content management system before, you’ll be able to use Mattrbld. For a content editor, it works almost like any other modern CMS.
+
+### Freedom at heart
+
+With Mattrbld, everything is decentralised. You control where your content is stored. In what shape it is delivered to a frontend. How it is presented to the public.
+
+### User centred
+
+User experience is a core pillar of Mattrbld. It leverages modern technologies to simplify complex processes while leaving you in control. No need to fight against the system.


### PR DESCRIPTION
This PR adds Mattrbld, a Git-based headless CMS for any SSG that can ingest JSON or Markdown. While it is currently not open source, there are plans to releasing it under a FOSS license in the future.

(I am the creator of Mattrbld.)