### PR TITLE
Fix broken links to SSG repos

### DIFF
--- a/src/site/generators/haunt.md
+++ b/src/site/generators/haunt.md
@@ -1,6 +1,5 @@
 ---
 title: Haunt
-repo: https://git.dthompson.us/haunt.git
 homepage: https://dthompson.us/projects/haunt.html
 language:
   - Guile

--- a/src/site/generators/quarto.md
+++ b/src/site/generators/quarto.md
@@ -1,6 +1,6 @@
 ---
 title: Quarto
-repo: https://github.com/quarto-dev/quarto-cli
+repo: quarto-dev/quarto-cli
 homepage: https://quarto.org/
 language:
     - TypeScript

--- a/src/site/generators/stog.md
+++ b/src/site/generators/stog.md
@@ -1,6 +1,5 @@
 ---
 title: Stog
-repo: zoggy/stog
 homepage: https://www.good-eris.net/stog/
 language:
   - OCaml


### PR DESCRIPTION
These three repo links were broken:

- Haunt
  - Before: `https://github.com/https://github.com/quarto-dev/quarto-cli`
  - After: `https://github.com/quarto-dev/quarto-cli`
- Quarto
  - Before: `https://github.com/https://git.dthompson.us/haunt.git`
  - After: *removed* (the repo on sourcehut can be found through the homepage link)
- Stog
  - Before: `https://github.com/zoggy/stog` (non-existant)
  - After: *removed* (the repo on a custom gitlab instance can be found through the homepage link) 