### PR TITLE
Add starlight to generators

### DIFF
--- a/src/site/generators/astro.md
+++ b/src/site/generators/astro.md
@@ -4,6 +4,7 @@ repo: withastro/astro
 homepage: https://astro.build
 language:
   - JavaScript
+  - TypeScript
 license:
   - MIT
 templates:

--- a/src/site/generators/starlight.md
+++ b/src/site/generators/starlight.md
@@ -1,0 +1,38 @@
+---
+title: Starlight
+repo: withastro/starlight
+homepage: https://starlight.astro.build/
+language:
+  - JavaScript
+  - TypeScript
+license:
+  - MIT
+templates:
+  - Svelte
+  - React
+  - Preact
+  - Vue
+  - SolidJS
+  - Lit
+  - AlpineJS
+  - HTML
+  - Markdown
+  - MDX
+description: Build beautiful, accessible, high-performance documentation websites with Astro.
+---
+
+## Documentation that delights
+
+Includes: Site navigation, search, internationalization, SEO, easy-to-read typography, code highlighting, dark mode and more.
+
+## Powered by Astro
+
+Leverage the full power and performance of Astro. Extend Starlight with your favorite Astro integrations and libraries.
+
+## Markdown, Markdoc, and MDX
+
+Bring your favorite markup language. Starlight gives you built-in frontmatter validation with TypeScript type-safety.
+
+## Bring your own UI components
+
+Starlight ships as a framework-agnostic, complete docs solution. Extend with React, Vue, Svelte, Solid, and more.


### PR DESCRIPTION
I also added "TypeScript" to the `language` of Astro.
The language tracker on https://github.com/withastro/astro is currently showing 53.9% of TypeScript and 42.5% of JavaScript.