### PR TITLE
Add Collections CMS to Headless CMS section

### DIFF
--- a/src/site/headless-cms/collections.md
+++ b/src/site/headless-cms/collections.md
@@ -1,0 +1,39 @@
+---
+title: Collections
+repo: collectionscms/collections
+homepage: https://collections.dev
+twitter: CollectionsCMS
+opensource: "Yes"
+typeofcms: "API Driven"
+supportedgenerators:
+  - All
+description: Collections is a Headless CMS that allows you to API your WordPress posts by simply dragging and dropping them. Stop copying and pasting old posts to get started.
+---
+
+[Collections](https://collections.dev/) is a Headless CMS that allows you to API your WordPress posts by simply dragging and dropping them. Stop copying and pasting old posts to get started.
+
+<img src="https://cdn.collections.dev/pv-en.gif" alt="collections promotional video" />
+
+## Why Collections?
+
+The complexity of migration stands as a significant obstacle in embracing the new CMS. To address this, Collections incorporates a migration tool within the CMS. This streamlines the process, allowing you to effortlessly import posts exported from WordPress.
+
+Moreover, by releasing the script as open source, we are migrating away from WordPress with its diverse data structures. Constructive contributions that allow migration to any data are welcome.
+
+<br />
+
+## Get Started
+Get started in just one line with 
+
+<div class="bg-black text-white p-4 my-4">
+npx create-collections-app my-app
+</div>
+
+The [Get started](https://collections.dev/docs/get-started) documentation will help you get up and going quickly or view our full documentation.
+
+<br />
+
+## Learn more
+- Check out our [docs](https://collections.dev/docs/home)
+- [Get started](https://collections.dev/docs/get-started) for free
+- Try the [demo](https://demo.collections.dev/admin)


### PR DESCRIPTION
Hey!

Thanks for creating this great site!
This PR adds [Collections](https://collections.dev/) to the Headless CMS section.

Collections is a Headless CMS that allows you to API your WordPress posts by simply dragging and dropping them.

Thanks