### PR TITLE
Update repo path for linkfree-gen

### DIFF
--- a/src/site/generators/linkfree-gen.md
+++ b/src/site/generators/linkfree-gen.md
@@ -1,6 +1,6 @@
 ---
 title: LinkFree Generator
-repo: chriskthomas/linkfree-generator
+repo: writeplace/linkfree-generator
 homepage: https://ckt.im/linkfree/
 language:
   - PHP


### PR DESCRIPTION
I changed my GitHub username. So, the repo path has changed.

Original merged PR for identity verification: #894