### PR TITLE
Sculpin: added HTML & Markdown

### DIFF
--- a/src/site/generators/sculpin.md
+++ b/src/site/generators/sculpin.md
@@ -8,6 +8,8 @@ license:
   - MIT
 templates:
   - Twig
+  - HTML
+  - Markdown
 description: Sculpin is a static site generator written in PHP
 ---
 


### PR DESCRIPTION
The Sculpin website notes its ability to use plain HTML & Markdown (https://sculpin.io/)