### PR TITLE
add `sirius press` cms

### DIFF
--- a/src/site/headless-cms/sirius.md
+++ b/src/site/headless-cms/sirius.md
@@ -1,0 +1,16 @@
+---
+title: Sirius press
+homepage: 'https://www.sirius.press/'
+opensource: 'No'
+typeofcms: "API Driven"
+supportedgenerators:
+  - All
+description: Press oriented headless CMS built in with Le Monde newsroom leaders. Track entire articles production and plan cross-channels publications.
+---
+
+## Sirius press
+Sirius press is a set of high-end SaaS products built to overcome media digital challenges.
+
+Our softwares signature is the proximity between techs and publishers teams which allow fast iterations and tailor-made product crafting.
+
+Sirius was firstly built to match Le Monde newspaper publications' needs. The success of the application led us to use it for all Le Monde Group newsrooms and offer it outside the group's borders. 


### PR DESCRIPTION
Add https://www.sirius.press CMS

> Press oriented headless CMS built in with Le Monde newsroom leaders. Track entire articles production and plan cross-channels publications.

Used on: https://www.lemonde.fr