### PR TITLE
Correct license for Directus that is no longer open source

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "dist"
 
 [build.environment]
-  NODE_VERSION = "12.16.2"
+  NODE_VERSION = "22.17.1"
   NODE_ENV = "production"
 
 [dev]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/jamstack/jamstack.org"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=22"
   },
   "scripts": {
     "build": "npm-run-all build:html build:css",

--- a/src/site/headless-cms/directus.md
+++ b/src/site/headless-cms/directus.md
@@ -3,7 +3,7 @@ title: Directus
 repo: directus/directus
 homepage: https://directus.io
 twitter: directus
-opensource: "Yes"
+opensource: "No"
 typeofcms: "API Driven"
 supportedgenerators:
   - All


### PR DESCRIPTION
Directus is licensed under the Business Source License as of now (April 2025).

Source: https://github.com/directus/directus/blob/main/license