### PR TITLE
Remove confusing references to .Net

### DIFF
--- a/src/site/generators/AspNetStatic.md
+++ b/src/site/generators/AspNetStatic.md
@@ -4,7 +4,6 @@ repo: ZarehD/AspNetStatic
 homepage: https://github.com/ZarehD/AspNetStatic
 language:
   - C#
-  - .Net
 license:
   - Apache-2.0
 templates:

--- a/src/site/generators/baker.md
+++ b/src/site/generators/baker.md
@@ -3,7 +3,7 @@ title: Misakai Baker
 repo: Kelindar/misakai-baker
 homepage: http://baker.misakai.com
 language:
-  - .Net
+  - C#
 license:
   - Apache-2.0
 templates:

--- a/src/site/generators/blazorstatic.md
+++ b/src/site/generators/blazorstatic.md
@@ -4,7 +4,6 @@ repo: tesar-tech/BlazorStatic
 homepage: https://github.com/tesar-tech/BlazorStatic
 language:
   - C#
-  - .Net
 license:
   - AGPL-3.0 license
 templates:

--- a/src/site/generators/graze.md
+++ b/src/site/generators/graze.md
@@ -3,7 +3,7 @@ title: graze
 repo: mikoskinen/graze
 homepage: http://mikaelkoskinen.net/graze-static-site-generator-using-razor
 language:
-  - .Net
+  - C#
 license:
   - MIT
 templates:

--- a/src/site/generators/iron-beard.md
+++ b/src/site/generators/iron-beard.md
@@ -3,7 +3,7 @@ title: IronBeard
 repo: wkallhof/iron-beard
 homepage: https://github.com/wkallhof/iron-beard
 language:
-  - .Net
+  - C#
 license:
   - MIT
 templates:

--- a/src/site/generators/lastpage.md
+++ b/src/site/generators/lastpage.md
@@ -3,7 +3,6 @@ title: lastpage
 repo: tomzorz/lastpage
 homepage: https://github.com/tomzorz/lastpage
 language:
-  - .Net
   - C#
 license:
   - MIT

--- a/src/site/generators/pretzel.md
+++ b/src/site/generators/pretzel.md
@@ -3,7 +3,7 @@ title: pretzel
 repo: Code52/pretzel
 homepage: http://code52.org/pretzel.html
 language:
-  - .Net
+  - C#
 license:
   - MS-PL
 templates:

--- a/src/site/generators/record-collector.md
+++ b/src/site/generators/record-collector.md
@@ -3,7 +3,6 @@ title: Record Collector
 repo: krompaco/record-collector
 homepage: https://record-collector.net/en/
 language:
-  - .Net
   - C#
 license:
   - MIT

--- a/src/site/generators/statiq.md
+++ b/src/site/generators/statiq.md
@@ -3,7 +3,7 @@ title: Statiq
 repo: statiqdev/Statiq.Web
 homepage: https://statiq.dev/web/
 language:
-  - .Net
+  - C#
 license:
   - Prosperity Public License
 templates:

--- a/src/site/generators/wyam.md
+++ b/src/site/generators/wyam.md
@@ -3,7 +3,7 @@ title: Wyam
 repo: Wyamio/Wyam
 homepage: http://wyam.io
 language:
-  - .Net
+  - C#
 license:
   - MIT
 templates:


### PR DESCRIPTION
Some static site generators listed include their language as ".Net". As dotnet is a framework and not a language itself, and some other frameworks correctly list "C#" as their language, this is confusing to users reading the list.

This PR removes the ".Net" language, replacing it with "C#" as all generators with ".Net" use C#.