### PR TITLE
Upgrade Node.js version on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "dist"
 
 [build.environment]
-  NODE_VERSION = "12.16.2"
+  NODE_VERSION = "22.17.1"
   NODE_ENV = "production"
 
 [dev]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/jamstack/jamstack.org"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=22"
   },
   "scripts": {
     "build": "npm-run-all build:html build:css",


### PR DESCRIPTION
Currently, this project uses Node.js 12, which reached EOL 6 years ago, on Netlify.
Due to too old Node.js version, the `postcss` command fails to build the stylesheet in #1012.

This PR upgrades Node.js to v22, the latest LTS.