### PR TITLE
Add PicoSSG.dev

### DIFF
--- a/src/site/generators/picossg.md
+++ b/src/site/generators/picossg.md
@@ -1,6 +1,6 @@
 ---
 title: PicoSSG
-repo: [wolframkriesing/picossg](https://codeberg.org/wolframkriesing/picossg)
+repo: https://codeberg.org/wolframkriesing/picossg
 homepage: https://picossg.dev/
 language:
   - JavaScript


### PR DESCRIPTION
https://picoSSG.dev is a minimal static site generator that processes markdown, nunjucks templates, and static files into a clean website with no configuration.