### PR TITLE
Update hompage for Basildon SSG

### DIFF
--- a/src/site/generators/basildon.md
+++ b/src/site/generators/basildon.md
@@ -1,7 +1,7 @@
 ---
 title: Basildon
 repo: samwilson/basildon
-homepage: https://basildon.netlify.app/
+homepage: https://basildon.samwilson.id.au
 language:
   - PHP
 license:


### PR DESCRIPTION
The old URL still works, but the canonical one is now `basildon.samwilson.id.au`.