### PR TITLE
Fix and update statue.md

### DIFF
--- a/src/site/generators/statue.md
+++ b/src/site/generators/statue.md
@@ -4,7 +4,6 @@ repo: accretional/statue
 homepage: https://statue.dev/
 language:
   - Svelte
-  - Markdown
 license:
   - MIT
 templates:


### PR DESCRIPTION
Fix the github repo frontmatter to simply accretional/statue so that the link/star/other integrations work properly on the jamestack site. This is currently broken, see the github link at https://jamstack.org/generators/statue/ to https://github.com/https://github.com/accretional/statue

Also update the statue.md file to reflect the current README.md in https://github.com/accretional/statue